### PR TITLE
feat(nvim): nvm-default package

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -58,6 +58,8 @@ require('lazy').setup(
   }
 )
 
+require('nvm-default').setup()
+
 require 'keymaps'
 
 -- vim: ts=2 sts=2 sw=2 et

--- a/config/nvim/lua/nvm-default/init.lua
+++ b/config/nvim/lua/nvm-default/init.lua
@@ -1,0 +1,88 @@
+-- Get nvm default version and use it in node_host_prog
+-- and g.copilot_node_command.
+local M = {}
+
+M.name = 'nvm-default.nvim'
+M.version = '0.1.0' -- x-release-please-version
+
+-- Helper function to run a shell command
+---@param cmd string Run a shell command
+---@return string? Return the result of the command
+local function run_command(cmd)
+  local handle = io.popen(cmd)
+  if not handle then
+    return nil
+  end
+  local result = handle:read("*a")
+  handle:close()
+  return result and result:gsub("%s+$", "")
+end
+
+
+-- Helper function to show a notification
+---@param msg string Show a message
+---@param level number|"info"|"warn"|"error"|"trace" Notification level
+local function n(msg, level)
+  if msg == nil then
+    msg = M.name .. ": No message provided"
+  end
+  if level == nil then
+    level = "trace"
+  end
+
+  vim.notify(M.name .. ": " .. msg, level)
+end
+
+-- Default options
+---@class NvmDefaultOptions
+---@field nvm_path string Where nvm installation is located
+---@field notify_level number|"info"|"warn"|"error"|"trace" Notification level filter
+M.defaults = {
+  nvm_path = os.getenv("NVM_DIR") or os.getenv("HOME") .. "/.nvm",
+  notify_level = vim.g.nvm_default_notify_level or "info",
+}
+
+-- Fetch the NVM default version or fallback to node version
+---@param opts? NvmDefaultOptions Options
+function M.setup(opts)
+  local options = vim.tbl_deep_extend("force", M.defaults, opts or {})
+
+  local nvm_path = options.nvm_path
+  local node_version =
+      run_command(string.format("source %s/nvm.sh && nvm version default", nvm_path)) or
+      run_command(string.format("source %s/nvm.sh && nvm version node", nvm_path))
+
+  if node_version and node_version:match("^v") then
+    -- Set vim.g.node_host_prog and vim.g.copilot_node_command
+    local node_dir = string.format("%s/versions/node/%s", nvm_path, node_version)
+    local node_dir_bin = string.format("%s/bin", node_dir)
+    local node_bin = string.format("%s/node", node_dir_bin)
+    local node_host_bin = string.format("%s/neovim-node-host", node_dir_bin)
+
+    -- If node_dir isn't there, stop and show error
+    if not vim.fn.isdirectory(node_dir) then
+      n("Node.js dir " .. node_dir .. " does not exist", "error")
+      return
+    end
+
+    -- If node_bin isn't there, stop and show error
+    if not vim.fn.filereadable(node_bin) then
+      n("Node.js bin " .. node_bin .. " does not exist", "error")
+      return
+    end
+
+    if not vim.fn.filereadable(node_host_bin) then
+      n("neovim-host-prog " .. node_host_bin .. " does not exist", "error")
+      return
+    end
+
+    vim.env.PATH = node_dir_bin .. ":" .. vim.env.PATH
+
+    vim.g.node_host_prog = node_host_bin
+    vim.g.copilot_node_command = node_bin
+  else
+    n("Unable to determine the Node.js version from nvm.", "error")
+  end
+end
+
+return M

--- a/config/nvim/lua/nvm-default/init.lua
+++ b/config/nvim/lua/nvm-default/init.lua
@@ -1,5 +1,20 @@
 -- Get nvm default version and use it in node_host_prog
 -- and g.copilot_node_command.
+--
+-- This module automatically configures Neovim to use the default Node.js version
+-- from NVM. It requires a working NVM installation and 'default' alias to be set,
+-- and also neovim npm package to be installed.
+--
+-- You can install the neovim package by running:
+-- npm i --global neovim
+--
+-- Usage:
+--   require('nvm-default').setup({
+--     add_to_path = true,        -- optional: add NVM bin directory to PATH
+--     nvm_path = "~/.nvm",      -- optional: custom NVM installation path
+--     notify_level = "info"     -- optional: notification level
+--   })
+
 local M = {}
 
 M.name = 'nvm-default.nvim'
@@ -9,13 +24,8 @@ M.version = '0.1.0' -- x-release-please-version
 ---@param cmd string Run a shell command
 ---@return string? Return the result of the command
 local function run_command(cmd)
-  local handle = io.popen(cmd)
-  if not handle then
-    return nil
-  end
-  local result = handle:read("*a")
-  handle:close()
-  return result and result:gsub("%s+$", "")
+  local result = vim.fn.system(cmd)
+  return vim.v.shell_error == 0 and result:gsub("%s+$", "") or nil
 end
 
 
@@ -33,53 +43,66 @@ local function n(msg, level)
   vim.notify(M.name .. ": " .. msg, level)
 end
 
--- Default options
 ---@class NvmDefaultOptions
+---@field add_to_path boolean Add found NVM bin directory to PATH
 ---@field nvm_path string Where nvm installation is located
 ---@field notify_level number|"info"|"warn"|"error"|"trace" Notification level filter
+
+-- Default options
+---@type NvmDefaultOptions
 M.defaults = {
-  nvm_path = os.getenv("NVM_DIR") or os.getenv("HOME") .. "/.nvm",
+  add_to_path = vim.g.nvm_default_add_to_path or true,
+  nvm_path = vim.fn.expand(os.getenv("NVM_DIR") or "~/.nvm"),
   notify_level = vim.g.nvm_default_notify_level or "info",
 }
 
 -- Fetch the NVM default version or fallback to node version
----@param opts? NvmDefaultOptions Options
+---@param opts? NvmDefaultOptions Plugin options
 function M.setup(opts)
   local options = vim.tbl_deep_extend("force", M.defaults, opts or {})
 
   local nvm_path = options.nvm_path
   local node_version =
-      run_command(string.format("source %s/nvm.sh && nvm version default", nvm_path)) or
-      run_command(string.format("source %s/nvm.sh && nvm version node", nvm_path))
+      run_command(string.format(". %s/nvm.sh && nvm version default", nvm_path)) or
+      run_command(string.format(". %s/nvm.sh && nvm version node", nvm_path))
 
   if node_version and node_version:match("^v") then
     -- Set vim.g.node_host_prog and vim.g.copilot_node_command
-    local node_dir = string.format("%s/versions/node/%s", nvm_path, node_version)
-    local node_dir_bin = string.format("%s/bin", node_dir)
-    local node_bin = string.format("%s/node", node_dir_bin)
-    local node_host_bin = string.format("%s/neovim-node-host", node_dir_bin)
+    local current_nvm_version_path = string.format("%s/versions/node/%s", nvm_path, node_version)
+    local current_nvm_node_bin_path = string.format("%s/bin", current_nvm_version_path)
+    local current_nvm_node_bin = string.format("%s/node", current_nvm_node_bin_path)
+    local neovim_node_host_bin_path = string.format("%s/neovim-node-host", current_nvm_node_bin_path)
+
+    -- Collect missing files and directories errors for error output
+    local missing = {}
 
     -- If node_dir isn't there, stop and show error
-    if not vim.fn.isdirectory(node_dir) then
-      n("Node.js dir " .. node_dir .. " does not exist", "error")
-      return
+    if not vim.fn.isdirectory(current_nvm_version_path) then
+      table.insert(missing, "Node.js directory: " .. current_nvm_version_path)
     end
 
     -- If node_bin isn't there, stop and show error
-    if not vim.fn.filereadable(node_bin) then
-      n("Node.js bin " .. node_bin .. " does not exist", "error")
+    if not vim.fn.filereadable(current_nvm_node_bin) then
+      table.insert(missing, "Node.js binary: " .. current_nvm_node_bin)
+    end
+
+    if not vim.fn.filereadable(neovim_node_host_bin_path) then
+      table.insert(missing, "Neovim host binary: " .. neovim_node_host_bin_path)
+    end
+
+    if #missing > 0 then
+      n("Missing required files:\n- " .. table.concat(missing, "\n- "), "error")
       return
     end
 
-    if not vim.fn.filereadable(node_host_bin) then
-      n("neovim-host-prog " .. node_host_bin .. " does not exist", "error")
-      return
+    -- Add to PATH if requested. Can be turned off by setting if it messes with
+    -- other tools.
+    if options.add_to_path then
+      vim.env.PATH = current_nvm_node_bin_path .. ":" .. vim.env.PATH
     end
 
-    vim.env.PATH = node_dir_bin .. ":" .. vim.env.PATH
-
-    vim.g.node_host_prog = node_host_bin
-    vim.g.copilot_node_command = node_bin
+    vim.g.node_host_prog = neovim_node_host_bin_path
+    vim.g.copilot_node_command = current_nvm_node_bin
   else
     n("Unable to determine the Node.js version from nvm.", "error")
   end


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Neovim plugin that automatically fetches and sets the default Node.js version from NVM.
	- Added a setup function with customizable options for the plugin.

- **Bug Fixes**
	- Improved error handling for missing Node.js installations, with notifications for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->