### PR TITLE
Fix replacable helper typo

### DIFF
--- a/config/exports
+++ b/config/exports
@@ -213,7 +213,7 @@ get_sha256sum()
 # $2 - filename (string)
 #
 # Returns 1 when replaceable, 0 when not replaceable.
-replacable()
+replaceable()
 {
   FILE1="$1"
   FILE2="$2"

--- a/scripts/install-cheat-purebashbible.sh
+++ b/scripts/install-cheat-purebashbible.sh
@@ -59,7 +59,7 @@ process_chapters()
     header=$(grep -e '^[#] ' "$f" | head -1 | awk '{print tolower($2)}')
     cheat_file="$cheat_dest/$header"
 
-    if ! replacable "$f" "$cheat_file"; then
+    if ! replaceable "$f" "$cheat_file"; then
       cp "$f" "$cheat_file" && msg_run "Updated: $cheat_file"
     fi
 


### PR DESCRIPTION
## Summary
- rename `replacable()` to `replaceable()` in `config/exports`
- update script usage in `install-cheat-purebashbible.sh`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff122f064832f8246f769c62a2c69