### PR TITLE
feat(install): add automation and skip flags

### DIFF
--- a/local/dfm/cmd/install.sh
+++ b/local/dfm/cmd/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Installation functions for dfm, the dotfile manager
 #
 # @author Ismo Vuorinen <https://github.com/ivuorinen>
@@ -62,15 +63,15 @@ function all()
   lib::log "Installing all packages..."
 
   if [[ $SKIP_FONTS -eq 0 ]]; then
-    fonts "$@"
+    fonts
   fi
 
   if [[ $SKIP_BREW -eq 0 ]]; then
-    brew "$@"
+    brew
   fi
 
   if [[ $SKIP_CARGO -eq 0 ]]; then
-    cargo "$@"
+    cargo
   fi
 }
 
@@ -92,8 +93,6 @@ function all()
 #   fonts
 function fonts()
 {
-  # Parse options only when called directly
-  [[ -z ${SKIP_FONTS+x} ]] && parse_options "$@"
 
   if [[ $SKIP_FONTS -eq 1 ]]; then
     lib::log "Skipping fonts installation"
@@ -129,8 +128,7 @@ function fonts()
 #   brew
 function brew()
 {
-  # Parse options only when called directly
-  [[ -z ${SKIP_BREW+x} ]] && parse_options "$@"
+
 
   if [[ $SKIP_BREW -eq 1 ]]; then
     lib::log "Skipping Homebrew installation"
@@ -174,8 +172,7 @@ function brew()
 #   cargo
 function cargo()
 {
-  # Parse options only when called directly
-  [[ -z ${SKIP_CARGO+x} ]] && parse_options "$@"
+
 
   if [[ $SKIP_CARGO -eq 1 ]]; then
     lib::log "Skipping Rust and cargo installation"

--- a/local/dfm/cmd/install.sh
+++ b/local/dfm/cmd/install.sh
@@ -172,8 +172,6 @@ function brew()
 #   cargo
 function cargo()
 {
-  parse_options "$@"
-
   if [[ $SKIP_CARGO -eq 1 ]]; then
     lib::log "Skipping Rust and cargo installation"
     return 0

--- a/local/dfm/cmd/install.sh
+++ b/local/dfm/cmd/install.sh
@@ -92,7 +92,8 @@ function all()
 #   fonts
 function fonts()
 {
-  parse_options "$@"
+  # Parse options only when called directly
+  [[ -z ${SKIP_FONTS+x} ]] && parse_options "$@"
 
   if [[ $SKIP_FONTS -eq 1 ]]; then
     lib::log "Skipping fonts installation"
@@ -128,7 +129,8 @@ function fonts()
 #   brew
 function brew()
 {
-  parse_options "$@"
+  # Parse options only when called directly
+  [[ -z ${SKIP_BREW+x} ]] && parse_options "$@"
 
   if [[ $SKIP_BREW -eq 1 ]]; then
     lib::log "Skipping Homebrew installation"
@@ -172,6 +174,9 @@ function brew()
 #   cargo
 function cargo()
 {
+  # Parse options only when called directly
+  [[ -z ${SKIP_CARGO+x} ]] && parse_options "$@"
+
   if [[ $SKIP_CARGO -eq 1 ]]; then
     lib::log "Skipping Rust and cargo installation"
     return 0


### PR DESCRIPTION
## Summary
- add parse_options to support `--no-automation`, `--no-brew`, `--no-cargo`, and `--no-fonts`
- prompt for confirmation when not using `--no-automation`
- respect skip flags in each installation step

## Testing
- `pre-commit run --files local/dfm/cmd/install.sh` *(fails: CalledProcessError: git fetch origin)*
- `DOTFILES=$(pwd) ./local/dfm/dfm install all --no-automation --no-brew --no-cargo --no-fonts`
- `DOTFILES=$(pwd) ./local/dfm/dfm install all --no-brew --no-cargo`

------
https://chatgpt.com/codex/tasks/task_e_6849bdd5b93c832fac4d9860ec6c2a0b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for command-line options to skip specific installation steps (fonts, Homebrew, cargo) and to disable automation.
  - Installation steps now prompt for user confirmation when automation is enabled.
  - Automated installation of fonts, Homebrew, and cargo packages with error handling and conditional execution.
- **Improvements**
  - Installation process is more flexible and can conditionally execute or skip steps based on user input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->