### PR TITLE
test: fix dfm bats suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fix:markdown": "npx markdownlint -df .",
     "lint:prettier": "npx prettier . --check",
     "fix:prettier": "npx prettier . --write",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "bats tests/dfm"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/ivuorinen/dotfiles#readme",
   "devDependencies": {
     "@ivuorinen/base-configs": "^2.0.0",
+    "bats": "^1.12.0",
     "bundle-audit": "^0.1.0"
   },
   "packageManager": "yarn@1.22.22"

--- a/tests/dfm/main.bats
+++ b/tests/dfm/main.bats
@@ -1,0 +1,34 @@
+setup() {
+  PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+}
+
+@test "list_available_commands shows commands" {
+  run bash -c "export DFM_CMD_DIR=$PROJECT_ROOT/local/dfm/cmd; export DFM_LIB_DIR=$PROJECT_ROOT/local/dfm/lib; export TEMP_DIR=\$(mktemp -d); source $PROJECT_ROOT/local/dfm/lib/common.sh; source $PROJECT_ROOT/local/dfm/lib/utils.sh; set +e; main::list_available_commands"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Available commands"
+  echo "$output" | grep -q "install"
+}
+
+@test "interactive confirm returns 0 on yes" {
+  run bash -c "source $PROJECT_ROOT/local/dfm/lib/utils.sh; set +e; utils::interactive::confirm \"Proceed?\" <<< \"y\"; echo \$?"
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "0" ]
+}
+
+@test "interactive confirm returns 1 on no" {
+  run bash -c "source $PROJECT_ROOT/local/dfm/lib/utils.sh; set +e; utils::interactive::confirm \"Proceed?\" <<< \"n\"; echo \$?"
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "1" ]
+}
+
+@test "execute_command runs function" {
+  run bash -c "export DFM_CMD_DIR=$PROJECT_ROOT/local/dfm/cmd; export DFM_LIB_DIR=$PROJECT_ROOT/local/dfm/lib; export TEMP_DIR=\$(mktemp -d); source $PROJECT_ROOT/local/dfm/lib/common.sh; source $PROJECT_ROOT/local/dfm/lib/utils.sh; set +e; main::execute_command install fonts"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Installing fonts"
+}
+
+@test "execute_command fails on missing function" {
+  run bash -c "export DFM_CMD_DIR=$PROJECT_ROOT/local/dfm/cmd; export DFM_LIB_DIR=$PROJECT_ROOT/local/dfm/lib; export TEMP_DIR=\$(mktemp -d); source $PROJECT_ROOT/local/dfm/lib/common.sh; source $PROJECT_ROOT/local/dfm/lib/utils.sh; set +e; main::execute_command install nofunc >/dev/null 2>&1; echo \$?"
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "1" ]
+}


### PR DESCRIPTION
## Summary
- don't ship yarn.lock changes
- make tests work from any directory

## Testing
- `npx prettier package.json tests/dfm/main.bats --check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6849bde305b4832f82978444c613961f