### PR TITLE
fix(bin): PATH quoting in x-path-append

### DIFF
--- a/local/bin/x-path-append
+++ b/local/bin/x-path-append
@@ -39,6 +39,6 @@ for dir in "$@"; do
   esac
 
   # Append the directory to PATH.
-  export PATH="${PATH:+"$PATH:"}$dir"
+  export PATH="${PATH:+$PATH:}$dir"
   [ "$VERBOSE" -eq 1 ] && echo "Appended '$dir' to PATH."
 done


### PR DESCRIPTION
## Summary
- ensure x-path-append doesn't insert literal quotes into PATH

## Testing
- `bash -n local/bin/x-path-append`


------
https://chatgpt.com/codex/tasks/task_e_683feedc3928832f94b71d82e642affe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the syntax used for appending directories to the PATH environment variable, with no change to existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->