### PR TITLE
fix(common): validate log level after error function

### DIFF
--- a/local/dfm/lib/common.sh
+++ b/local/dfm/lib/common.sh
@@ -21,11 +21,6 @@ declare -A LOG_LEVELS=(
   [WARN]=2
   [ERROR]=3
 )
-LOG_LEVEL="${LOG_LEVEL:-INFO}"
-if [[ -z "${LOG_LEVELS[$LOG_LEVEL]+_}" ]]; then
-  lib::error "Invalid LOG_LEVEL: $LOG_LEVEL"
-  exit "${ERROR_CODES[INVALID_ARGUMENT]}"
-fi
 
 # Simple logging function
 #
@@ -77,6 +72,12 @@ lib::error()
 {
   printf '[%s] ERROR: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
 }
+
+LOG_LEVEL="${LOG_LEVEL:-INFO}"
+if [[ -z "${LOG_LEVELS[$LOG_LEVEL]+_}" ]]; then
+  lib::error "Invalid LOG_LEVEL: $LOG_LEVEL"
+  exit "${ERROR_CODES[INVALID_ARGUMENT]}"
+fi
 
 # Handle an error by logging an error message to the console
 # and exiting with an error code based on the error type.


### PR DESCRIPTION
## Summary
- move LOG_LEVEL validation to after lib::error is defined

## Testing
- `yarn lint:prettier`
- `yarn lint:markdown` *(fails: MD034/no-bare-urls)*
- `yarn test` *(fails: execute_command tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857176dc4d0832fb322979c23aaa6e4