### PR TITLE
feat(ci): use pr-lint action instead of reviewdog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Debug Changelog # Workflow name displayed on GitHub
 
 on:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,4 +26,4 @@ jobs:
     steps:
       - name: Run Linters
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@05cd983353b4e6d3213389801daf0f9ec2af7a77 # 25.6.17
+        uses: ivuorinen/actions/pr-lint@99f3911475dbb5b8d43d314b24c0882997433868 # 25.6.23

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,10 +1,8 @@
 ---
-# $schema: "https://json.schemastore.org/github-workflow.json"
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Lint Code Base
 
 on:
-  push:
-    branches: [master, main]
   pull_request:
     branches: [master, main]
 
@@ -15,15 +13,24 @@ concurrency:
 permissions: read-all
 
 jobs:
-  linters:
-    name: Linters
-
-    runs-on: self-hosted
-
+  Linter:
+    name: PR Lint
+    runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions: write-all
+    permissions:
+      statuses: write
+      contents: read
+      packages: read
 
     steps:
-      - name: Run Linters
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Yarn Lock Changes
+        uses: Simek/yarn-lock-changes@34017425198654c20162a4dfd4f238fbece9636f # v0.12.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@99f3911475dbb5b8d43d314b24c0882997433868 # 25.6.23
+        uses: ivuorinen/actions/pr-lint@9480614ba2231013d99dd5b9c730d2b105b9e160 # 25.6.25

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,8 +1,12 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
-name: Reviewdog
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Lint Code Base
 
-on: [push]
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,45 +20,10 @@ jobs:
 
     runs-on: self-hosted
 
+    timeout-minutes: 15
     permissions: write-all
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-
-      - name: GitHub Actions
-        uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-
-      - name: detect-secrets
-        uses: reviewdog/action-detect-secrets@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-
-      - name: markdownlint
-        uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-
-      - name: shfmt
-        uses: reviewdog/action-shfmt@d8f080930b9be5847b4f97e9f4122b81a82aaeac # v1.0.4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          shfmt_flags: |
-            --find
-            --list
-            --write
-            --diff
-            --simplify
-            --language-dialect bash
-            --indent 2
-            --binary-next-line
-            --case-indent
-            --space-redirects
-            --func-next-line
+      - name: Run Linters
+        # https://github.com/ivuorinen/actions
+        uses: ivuorinen/actions/pr-lint@05cd983353b4e6d3213389801daf0f9ec2af7a77 # 25.6.17

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Lint Code Base
 
 on:

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Release Daily State
 
 on:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Pre-commit autoupdate
 
 on:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   auto-update:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     permissions:
       contents: write

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Semantic PR
 
 on:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -29,4 +29,4 @@ jobs:
       issues: write
 
     steps:
-      - uses: ivuorinen/actions/sync-labels@main
+      - uses: ivuorinen/actions/sync-labels@05cd983353b4e6d3213389801daf0f9ec2af7a77 # 25.6.17

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Sync labels
 
 # yamllint disable-line rule:truthy

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -29,4 +29,4 @@ jobs:
       issues: write
 
     steps:
-      - uses: ivuorinen/actions/sync-labels@05cd983353b4e6d3213389801daf0f9ec2af7a77 # 25.6.17
+      - uses: ivuorinen/actions/sync-labels@99f3911475dbb5b8d43d314b24c0882997433868 # 25.6.23

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ permissions: read-all
 
 jobs:
   SyncLabels:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     permissions:
       issues: write

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/github-workflow.json
+# $schema: "https://json.schemastore.org/github-workflow.json"
 name: Update submodules
 
 on:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,29 @@
+---
+# Configuration file for MegaLinter
+# See all available variables at
+# https://megalinter.io/configuration/ and in linters documentation
+
+APPLY_FIXES: all
+SHOW_ELAPSED_TIME: false # Show elapsed time at the end of MegaLinter run
+PARALLEL: true
+VALIDATE_ALL_CODEBASE: true
+FILEIO_REPORTER: false # Generate file.io report
+GITHUB_STATUS_REPORTER: true # Generate GitHub status report
+IGNORE_GENERATED_FILES: true # Ignore generated files
+JAVASCRIPT_DEFAULT_STYLE: prettier # Default style for JavaScript
+PRINT_ALPACA: false # Print Alpaca logo in console
+SARIF_REPORTER: true # Generate SARIF report
+SHOW_SKIPPED_LINTERS: false # Show skipped linters in MegaLinter log
+TYPESCRIPT_DEFAULT_STYLE: prettier # Default style for TypeScript
+
+DISABLE_LINTERS:
+  - REPOSITORY_DEVSKIM
+
+YAML_YAMLLINT_CONFIG_FILE: .yamllint.yml
+MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.json
+JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.json
+TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.json
+
+FILTER_REGEX_EXCLUDE: >
+  (node_modules|tools|config/cheat/cheatsheets/community|config/cheat/cheatsheets/tldr|config/fzf|config/zsh|config/tmux/plugins)
+


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve their configuration and streamline their execution. Key changes include modifying workflows to run on self-hosted runners, updating branch triggers, consolidating linter steps, and enhancing timeout settings.

### Workflow Configuration Updates:

* [`.github/workflows/linters.yml`](diffhunk://#diff-c94729f5aa1afabfd250d3a929cdc840199d92facd4c83fcbc37b661d784d4acL2-R9): Updated the branch triggers for `push` and `pull_request` events to include `master` and `main`. Renamed the workflow to "Lint Code Base" and replaced individual linter steps with a consolidated "Run Linters" step using the `ivuorinen/actions/pr-lint` action. Added a timeout of 15 minutes for the job. [[1]](diffhunk://#diff-c94729f5aa1afabfd250d3a929cdc840199d92facd4c83fcbc37b661d784d4acL2-R9) [[2]](diffhunk://#diff-c94729f5aa1afabfd250d3a929cdc840199d92facd4c83fcbc37b661d784d4acR23-R29)

### Runner Changes:

* [`.github/workflows/pre-commit-autoupdate.yml`](diffhunk://#diff-86f8b7ef24a2fb6561998f0f80f33207b4010348d6b3031a2b12c16b6c814b1fL19-R19): Changed the runner from `ubuntu-latest` to `self-hosted` for the `auto-update` job.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L26-R26): Changed the runner from `ubuntu-latest` to `self-hosted` for the `SyncLabels` job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified and consolidated the linting workflow with improved concurrency control, expanded triggers, and updated permissions.
  - Updated runner environments for the "Pre-commit autoupdate" and "SyncLabels" workflows to use self-hosted runners instead of the default environment.
  - Standardized workflow schema declarations across all GitHub Actions workflows.
  - Added a new configuration file for MegaLinter with enhanced linting settings and customizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->