### PR TITLE
docs(agents): update instructions for yarn

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -4,22 +4,22 @@ These instructions help language models work with this repository.
 
 ## Setup
 
-1. Run `npm install` to get linting tools and the Bats test framework.
+1. Run `yarn install` to get linting tools and the Bats test framework.
 
 ## Formatting
 
 - Format code and docs with Prettier and markdownlint:
 
 ```bash
-npm run fix:prettier
-npm run fix:markdown
+yarn fix:prettier
+yarn fix:markdown
 ```
 
 - Shell scripts should pass `shellcheck`.
 
 ## Testing
 
-- When code changes, run `npm test` to execute Bats tests.
+- When code changes, run `yarn test` to execute Bats tests.
 - If only comments or documentation change, tests may be skipped.
 
 ## Commits and PRs


### PR DESCRIPTION
## Summary
- clarify that contributors should use `yarn`

## Testing
- `yarn fix:prettier`
- `yarn fix:markdown`


------
https://chatgpt.com/codex/tasks/task_e_6861e9f60a34832fbada0cb19c41c466