### PR TITLE
fix(scripts): correct usage and help exit status

### DIFF
--- a/local/bin/x-gh-get-latest-version
+++ b/local/bin/x-gh-get-latest-version
@@ -97,7 +97,7 @@ Examples:
   # Use GitHub Enterprise API
   GITHUB_API_URL="https://github.example.com/api/v3/repos" $BIN ivuorinen/dotfiles
 EOF
-  exit 1
+  exit 0
 }
 
 # Check that required dependencies are installed

--- a/local/bin/x-mkd
+++ b/local/bin/x-mkd
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Create a directory and cd into it
-# Usage: mkcd <dir>
+# Usage: x-mkd <dir>
 
 set -euo pipefail
 

--- a/tests/x-gh-get-latest-version.bats
+++ b/tests/x-gh-get-latest-version.bats
@@ -2,6 +2,6 @@
 
 @test "x-gh-get-latest-version help" {
   run bash local/bin/x-gh-get-latest-version --help
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [[ "$output" == "Usage: x-gh-get-latest-version"* ]]
 }

--- a/tests/x-localip.bats
+++ b/tests/x-localip.bats
@@ -5,3 +5,9 @@
   [ "$status" -eq 0 ]
   [[ "$output" == "x-localip version"* ]]
 }
+
+@test "x-localip help" {
+  run bash local/bin/x-localip --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == "Usage:"* ]]
+}

--- a/tests/x-mkd.bats
+++ b/tests/x-mkd.bats
@@ -6,3 +6,9 @@
   [ "$status" -eq 0 ]
   [ -d "$dir" ]
 }
+
+@test "x-mkd with no args shows usage" {
+  run bash local/bin/x-mkd
+  [ "$status" -eq 1 ]
+  [[ "$output" == "Usage:"* ]]
+}

--- a/tests/x-path.bats
+++ b/tests/x-path.bats
@@ -20,3 +20,9 @@
   VERBOSE=1 source local/bin/x-path-remove "$BATS_TMPDIR/dir"
   [ "$PATH" = "/usr/bin" ]
 }
+
+@test "x-path-append skips missing directory" {
+  PATH="/usr/bin"
+  VERBOSE=1 source local/bin/x-path-append "$BATS_TMPDIR/no-such"
+  [ "$PATH" = "/usr/bin" ]
+}


### PR DESCRIPTION
## Summary
- fix usage comment in `x-mkd`
- exit with status 0 when showing help in `x-gh-get-latest-version`
- expand tests for `x-mkd`, `x-localip`, and `x-path`
- update expectations for help output

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68621c2bc16c832f91835a7c6b8e4bdc