### PR TITLE
fix(theme): route watcher via portal off GNOME, seed on start

### DIFF
--- a/config/theme/watcher
+++ b/config/theme/watcher
@@ -68,6 +68,17 @@ apply_mode()
   "$apply_cmd" "$m" || true
 }
 
+# Map a gsettings color-scheme value to the corresponding mode and
+# apply it. Input is the raw `gsettings get` output (single-quoted).
+# Unrecognised or unset values are no-ops, matching prior behavior.
+apply_gsettings_scheme()
+{
+  case "$1" in
+    "'prefer-dark'") apply_mode dark ;;
+    "'default'" | "'prefer-light'") apply_mode light ;;
+  esac
+}
+
 # Seed the cached state from the OS *once* at startup. The Linux event
 # loops (gsettings / busctl monitor) only fire on change, so without
 # this a watcher started against a stale cache stays stale until the
@@ -78,12 +89,8 @@ seed_initial_state()
   local src="$1"
   case "$src" in
     gsettings)
-      local scheme
-      scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
-      case "$scheme" in
-        "'prefer-dark'") apply_mode dark ;;
-        "'default'" | "'prefer-light'") apply_mode light ;;
-      esac
+      apply_gsettings_scheme \
+        "$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
       ;;
     busctl)
       local initial
@@ -165,11 +172,8 @@ case "$SOURCE" in
         seed_initial_state gsettings
         gsettings monitor org.gnome.desktop.interface color-scheme 2> /dev/null \
           | while IFS= read -r _; do
-            scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
-            case "$scheme" in
-              "'prefer-dark'") apply_mode dark ;;
-              "'default'" | "'prefer-light'") apply_mode light ;;
-            esac
+            apply_gsettings_scheme \
+              "$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
           done
         ;;
       busctl)

--- a/config/theme/watcher
+++ b/config/theme/watcher
@@ -4,8 +4,12 @@
 # change.
 #
 # OS sources (auto-detected, override with --source):
-#   linux  : prefers `gsettings monitor`; falls back to `busctl monitor`
-#            for non-GNOME; exits 0 if neither reachable.
+#   linux  : on GNOME (XDG_CURRENT_DESKTOP matches *GNOME*) prefers
+#            `gsettings monitor`; on other DEs (COSMIC, KDE, …) prefers
+#            `busctl monitor` against the freedesktop portal, since
+#            those DEs leave `org.gnome.desktop.interface color-scheme`
+#            untouched. Falls back to whichever is available; exits 0
+#            if neither is.
 #   macos  : 2s `defaults read` polling.
 #   stub   : reads modes (one per line) from --stub-input. Test seam.
 set -uo pipefail
@@ -64,6 +68,42 @@ apply_mode()
   "$apply_cmd" "$m" || true
 }
 
+# Seed the cached state from the OS *once* at startup. The Linux event
+# loops (gsettings / busctl monitor) only fire on change, so without
+# this a watcher started against a stale cache stays stale until the
+# next user toggle. `apply_mode` → `apply` is idempotent, so this is a
+# no-op when the cache already agrees with the OS.
+seed_initial_state()
+{
+  local src="$1"
+  case "$src" in
+    gsettings)
+      local scheme
+      scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
+      case "$scheme" in
+        "'prefer-dark'") apply_mode dark ;;
+        "'default'" | "'prefer-light'") apply_mode light ;;
+      esac
+      ;;
+    busctl)
+      local initial
+      initial="$(busctl --user --json=short call \
+        org.freedesktop.portal.Desktop \
+        /org/freedesktop/portal/desktop \
+        org.freedesktop.portal.Settings Read \
+        ss org.freedesktop.appearance color-scheme 2> /dev/null || true)"
+      # busctl --json=short types the integer as `"u"`, so the pattern
+      # `"u","data":N` is anchored on the type tag and won't false-match
+      # any other integer that happens to appear in the payload. data:0
+      # ("no preference") is intentionally ignored.
+      case "$initial" in
+        *'"u","data":1'*) apply_mode dark ;;
+        *'"u","data":2'*) apply_mode light ;;
+      esac
+      ;;
+  esac
+}
+
 case "$SOURCE" in
   stub)
     [[ -r "$STUB_INPUT" ]] || {
@@ -91,33 +131,67 @@ case "$SOURCE" in
     done
     ;;
   linux)
-    if command -v gsettings > /dev/null 2>&1; then
-      _log "INFO watcher: subscribing via gsettings monitor"
-      gsettings monitor org.gnome.desktop.interface color-scheme 2> /dev/null \
-        | while IFS= read -r _; do
-          scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
-          case "$scheme" in
-            "'prefer-dark'") apply_mode dark ;;
-            "'default'" | "'prefer-light'") apply_mode light ;;
-          esac
-        done
-    elif command -v busctl > /dev/null 2>&1; then
-      _log "INFO watcher: subscribing via busctl monitor (portal)"
-      busctl --user --json=short monitor org.freedesktop.portal.Desktop 2> /dev/null \
-        | while IFS= read -r line; do
-          # Anchor on the JSON variant token so we don't false-match
-          # timestamps or sequence numbers that happen to contain 1/2.
-          # busctl --json=short emits `"v":1` (dark) / `"v":2` (light)
-          # for the org.freedesktop.appearance color-scheme settings.
-          case "$line" in
-            *'"color-scheme"'*'"v":1'*) apply_mode dark ;;
-            *'"color-scheme"'*'"v":2'*) apply_mode light ;;
-          esac
-        done
-    else
-      _log "WARN watcher linux: neither gsettings nor busctl available; exiting"
-      exit 0
+    # Pick the event source. GNOME (and forks like ubuntu:GNOME) write
+    # to `org.gnome.desktop.interface color-scheme`, so `gsettings
+    # monitor` fires reliably there. Other DEs (COSMIC, KDE, …) leave
+    # that schema untouched even when `gsettings` is installed; their
+    # appearance toggle only updates the freedesktop portal. Default
+    # to busctl off-GNOME, gsettings on-GNOME, and fall back to the
+    # other when only one of the two is available.
+    have_gsettings=false
+    have_busctl=false
+    command -v gsettings > /dev/null 2>&1 && have_gsettings=true
+    command -v busctl > /dev/null 2>&1 && have_busctl=true
+
+    case "${XDG_CURRENT_DESKTOP:-}" in
+      *GNOME*) prefer="gsettings" ;;
+      *) prefer="busctl" ;;
+    esac
+
+    use=""
+    if [[ "$prefer" = "gsettings" ]] && "$have_gsettings"; then
+      use="gsettings"
+    elif [[ "$prefer" = "busctl" ]] && "$have_busctl"; then
+      use="busctl"
+    elif "$have_gsettings"; then
+      use="gsettings"
+    elif "$have_busctl"; then
+      use="busctl"
     fi
+
+    case "$use" in
+      gsettings)
+        _log "INFO watcher: subscribing via gsettings monitor"
+        seed_initial_state gsettings
+        gsettings monitor org.gnome.desktop.interface color-scheme 2> /dev/null \
+          | while IFS= read -r _; do
+            scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
+            case "$scheme" in
+              "'prefer-dark'") apply_mode dark ;;
+              "'default'" | "'prefer-light'") apply_mode light ;;
+            esac
+          done
+        ;;
+      busctl)
+        _log "INFO watcher: subscribing via busctl monitor (portal) — DE='${XDG_CURRENT_DESKTOP:-}'"
+        seed_initial_state busctl
+        busctl --user --json=short monitor org.freedesktop.portal.Desktop 2> /dev/null \
+          | while IFS= read -r line; do
+            # Anchor on the JSON variant token so we don't false-match
+            # timestamps or sequence numbers that happen to contain 1/2.
+            # busctl --json=short emits `"v":1` (dark) / `"v":2` (light)
+            # for the org.freedesktop.appearance color-scheme settings.
+            case "$line" in
+              *'"color-scheme"'*'"v":1'*) apply_mode dark ;;
+              *'"color-scheme"'*'"v":2'*) apply_mode light ;;
+            esac
+          done
+        ;;
+      *)
+        _log "WARN watcher linux: neither gsettings nor busctl available; exiting"
+        exit 0
+        ;;
+    esac
     ;;
   *)
     echo "watcher: unknown --source '$SOURCE'" >&2

--- a/tests/theme-watcher.bats
+++ b/tests/theme-watcher.bats
@@ -3,10 +3,39 @@
 setup()
 {
   TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
   export XDG_STATE_HOME="$TMPDIR_TEST"
   export THEME_HANDLERS_DIR="$TMPDIR_TEST/handlers.d"
   mkdir -p "$THEME_HANDLERS_DIR"
   WATCHER="$BATS_TEST_DIRNAME/../config/theme/watcher"
+
+  # Curated PATH sandbox for the linux-source tests below. $BIN holds
+  # fake gsettings/busctl binaries that each test installs as needed;
+  # $UTIL holds symlinks to the coreutils + bash + timeout the watcher
+  # and _lib.sh actually rely on. With PATH=$BIN:$UTIL only, the
+  # watcher's `command -v gsettings` / `command -v busctl` reflect
+  # exactly what the test placed in $BIN — host-installed binaries on
+  # /usr/bin become invisible.
+  BIN="$TMPDIR_TEST/bin"
+  UTIL="$TMPDIR_TEST/util"
+  mkdir -p "$BIN" "$UTIL"
+  for cmd in bash env mkdir dirname mktemp mv ln rm cat date tail wc kill sleep printf timeout gtimeout awk grep; do
+    real="$(command -v "$cmd" 2> /dev/null || true)"
+    [[ -n "$real" && -e "$real" ]] && ln -sf "$real" "$UTIL/$cmd" || true
+  done
+  ISO_PATH="$BIN:$UTIL"
+  TIMEOUT_BIN=""
+  [[ -x "$UTIL/timeout" ]] && TIMEOUT_BIN="$UTIL/timeout"
+  [[ -z "$TIMEOUT_BIN" && -x "$UTIL/gtimeout" ]] && TIMEOUT_BIN="$UTIL/gtimeout"
+
+  # Recorder handler — captures the mode the actor passed to handlers.
+  # Shared by stub-source and linux-source tests; install once here so
+  # the per-test setup stays focused on its specific scenario.
+  cat > "$THEME_HANDLERS_DIR/recorder" << 'HND'
+#!/usr/bin/env bash
+echo "$1" >> "${TMPDIR_TEST}/recorded"
+HND
+  chmod +x "$THEME_HANDLERS_DIR/recorder"
 }
 
 teardown()
@@ -18,16 +47,64 @@ teardown()
   rm -rf "$TMPDIR_TEST"
 }
 
+# --- Helpers for the linux-source tests ---
+
+# Install a fake `gsettings` in $BIN. $1 is the raw value `gsettings
+# get` should print (single-quoted, e.g. "'prefer-dark'"). The fake
+# `monitor` subcommand exits 0 with no output so the watcher's
+# `monitor | while read` pipeline sees EOF immediately and exits.
+fake_gsettings()
+{
+  local scheme="$1"
+  cat > "$BIN/gsettings" << STUB
+#!/usr/bin/env bash
+printf 'gsettings %s\n' "\$*" >> "$BIN/calls"
+case "\$1" in
+  get) echo "${scheme}" ;;
+  monitor) ;;
+esac
+STUB
+  chmod +x "$BIN/gsettings"
+}
+
+# Install a fake `busctl`. $1 is the integer the synchronous
+# Settings.Read should report inside the JSON variant (1=dark,
+# 2=light, 0=no preference). The `monitor` subcommand exits 0 with
+# no output, same trick as fake_gsettings.
+fake_busctl()
+{
+  local n="$1"
+  cat > "$BIN/busctl" << STUB
+#!/usr/bin/env bash
+printf 'busctl %s\n' "\$*" >> "$BIN/calls"
+mode=
+for a in "\$@"; do
+  case "\$a" in
+    call) mode=call ;;
+    monitor) mode=monitor ;;
+  esac
+done
+case "\$mode" in
+  call) printf '{"type":"v","data":[{"type":"v","data":{"type":"u","data":%s}}]}\n' "${n}" ;;
+  monitor) ;;
+esac
+STUB
+  chmod +x "$BIN/busctl"
+}
+
+run_watcher_linux()
+{
+  local de="$1"
+  PATH="$ISO_PATH" XDG_CURRENT_DESKTOP="$de" \
+    "$TIMEOUT_BIN" 3 "$WATCHER" --source linux
+}
+
+# --- Existing tests ---
+
 @test "watcher: --source stub reads modes from a file and applies each" {
   tmo="$(command -v timeout 2> /dev/null || command -v gtimeout 2> /dev/null || true)"
   [ -n "$tmo" ] || skip "no timeout(1) on PATH"
-  cat > "$THEME_HANDLERS_DIR/recorder" << 'STUB'
-#!/usr/bin/env bash
-echo "$1" >> "${TMPDIR_TEST}/recorded"
-STUB
-  chmod +x "$THEME_HANDLERS_DIR/recorder"
   printf 'dark\nlight\ndark\n' > "$TMPDIR_TEST/source-stub"
-  export TMPDIR_TEST
   run "$tmo" 3 "$WATCHER" --source stub --stub-input "$TMPDIR_TEST/source-stub"
   [ "$status" -eq 0 ]
   [ "$(wc -l < "$TMPDIR_TEST/recorded")" -ge 3 ]
@@ -40,4 +117,98 @@ STUB
   }
   run "$WATCHER" --source stub --stub-input /dev/null
   [ "$status" -eq 1 ]
+}
+
+# --- Linux source-selection + initial-seed tests ---
+
+@test "watcher linux: GNOME prefers gsettings; seed applies before monitor" {
+  [ -n "$TIMEOUT_BIN" ] || skip "no timeout(1) on PATH"
+  fake_gsettings "'prefer-dark'"
+  fake_busctl 1 # would also map to dark, but must NOT be invoked
+
+  run run_watcher_linux GNOME
+  [ "$status" -eq 0 ]
+
+  # gsettings was used for both seed get and monitor; busctl untouched.
+  grep -q '^gsettings get org.gnome.desktop.interface color-scheme$' "$BIN/calls"
+  grep -q '^gsettings monitor org.gnome.desktop.interface color-scheme$' "$BIN/calls"
+  run grep -q '^busctl' "$BIN/calls"
+  [ "$status" -ne 0 ]
+
+  # Seed-before-monitor ordering proven by the calls log.
+  first=$(awk 'NR==1' "$BIN/calls")
+  second=$(awk 'NR==2' "$BIN/calls")
+  [[ "$first" == "gsettings get"* ]]
+  [[ "$second" == "gsettings monitor"* ]]
+
+  # Seed applied 'dark' to handlers and the state file before the
+  # monitor pipeline started — the recorder ran inside `apply` which
+  # `seed_initial_state` calls synchronously.
+  [ "$(cat "$TMPDIR_TEST/recorded")" = "dark" ]
+  [ "$(cat "$TMPDIR_TEST/dotfiles-theme/mode")" = "dark" ]
+}
+
+@test "watcher linux: COSMIC prefers busctl portal; data:2 -> light seed" {
+  [ -n "$TIMEOUT_BIN" ] || skip "no timeout(1) on PATH"
+  fake_gsettings "'prefer-dark'" # would map to dark; must NOT be invoked
+  fake_busctl 2                  # data:2 = light
+
+  run run_watcher_linux COSMIC
+  [ "$status" -eq 0 ]
+
+  # busctl was used (call for seed, monitor for events); gsettings untouched.
+  grep -q '^busctl --user --json=short call ' "$BIN/calls"
+  grep -q '^busctl --user --json=short monitor org.freedesktop.portal.Desktop$' "$BIN/calls"
+  run grep -q '^gsettings' "$BIN/calls"
+  [ "$status" -ne 0 ]
+
+  first=$(awk 'NR==1' "$BIN/calls")
+  second=$(awk 'NR==2' "$BIN/calls")
+  [[ "$first" == "busctl "*" call "* ]]
+  [[ "$second" == "busctl "*" monitor "* ]]
+
+  [ "$(cat "$TMPDIR_TEST/recorded")" = "light" ]
+  [ "$(cat "$TMPDIR_TEST/dotfiles-theme/mode")" = "light" ]
+}
+
+@test "watcher linux: ubuntu:GNOME falls back to busctl when gsettings absent" {
+  [ -n "$TIMEOUT_BIN" ] || skip "no timeout(1) on PATH"
+  fake_busctl 1 # data:1 = dark
+
+  # ubuntu:GNOME also matches `*GNOME*` — exercises the wildcard and the
+  # have_gsettings=false branch of the selector.
+  run run_watcher_linux ubuntu:GNOME
+  [ "$status" -eq 0 ]
+
+  run grep -q '^gsettings' "$BIN/calls"
+  [ "$status" -ne 0 ]
+  grep -q '^busctl ' "$BIN/calls"
+  [ "$(cat "$TMPDIR_TEST/recorded")" = "dark" ]
+  [ "$(cat "$TMPDIR_TEST/dotfiles-theme/mode")" = "dark" ]
+}
+
+@test "watcher linux: COSMIC falls back to gsettings when busctl absent" {
+  [ -n "$TIMEOUT_BIN" ] || skip "no timeout(1) on PATH"
+  fake_gsettings "'prefer-light'"
+
+  run run_watcher_linux COSMIC
+  [ "$status" -eq 0 ]
+
+  run grep -q '^busctl' "$BIN/calls"
+  [ "$status" -ne 0 ]
+  grep -q '^gsettings ' "$BIN/calls"
+  [ "$(cat "$TMPDIR_TEST/recorded")" = "light" ]
+  [ "$(cat "$TMPDIR_TEST/dotfiles-theme/mode")" = "light" ]
+}
+
+@test "watcher linux: neither gsettings nor busctl -> exit 0 with WARN" {
+  [ -n "$TIMEOUT_BIN" ] || skip "no timeout(1) on PATH"
+
+  run run_watcher_linux GNOME
+  [ "$status" -eq 0 ]
+
+  grep -q 'WARN watcher linux: neither gsettings nor busctl available' \
+    "$TMPDIR_TEST/dotfiles-theme/log"
+  [ ! -e "$BIN/calls" ]
+  [ ! -e "$TMPDIR_TEST/recorded" ]
 }


### PR DESCRIPTION
## Summary

- **DE-aware event source.** `XDG_CURRENT_DESKTOP=*GNOME*` keeps `gsettings monitor`; everything else (COSMIC, KDE, Hyprland, …) prefers `busctl monitor` against `org.freedesktop.portal.Desktop`. Either tool falls back to the other when only one is installed; both missing → `_log WARN` + `exit 0` (unchanged).
- **Initial-state seed.** New `seed_initial_state` helper queries the OS once at startup (`gsettings get` or a synchronous `org.freedesktop.portal.Settings.Read`) and applies the result before entering the monitor loop. Linux monitors only emit on *change*, so without seeding a watcher started against a stale cache stayed stale until the next user toggle. `apply` is idempotent, so the seed is a no-op when cache and OS already agree.
- **Bug it fixes.** On Pop!_OS COSMIC, the watcher subscribed via `gsettings monitor org.gnome.desktop.interface color-scheme`, but COSMIC never writes to that schema — events never fired, the cache went stale, and `theme-reapply` re-fired the wrong mode. Symptoms reported [here](#).

## Test plan

- [x] `bash -n config/theme/watcher`
- [x] `shellcheck config/theme/watcher` (clean)
- [x] `shfmt -i 2 -bn -ci -sr -fn -d config/theme/watcher` (clean — matches project pre-commit args)
- [x] `yarn lint:ec` (clean)
- [x] Selector smoke test: COSMIC→busctl, ubuntu:GNOME→gsettings, KDE/no-busctl→gsettings (fallback), empty/no-gsettings→busctl (fallback), neither→exit 0
- [x] Live verified on Pop!_OS COSMIC: watcher subscribed via `INFO watcher: subscribing via busctl monitor (portal) — DE='COSMIC'`; `seed_initial_state` flipped a stale `dark` cache → `light` immediately on startup with no user toggle (`INFO actor flipped to light` 13s after subscribe)
- [x] busctl monitor child process confirmed in process tree (no `gsettings monitor` child)
- [x] Reviewer: toggle GNOME or COSMIC appearance and confirm `actor flipped to {dark,light}` appears in `$XDG_STATE_HOME/dotfiles-theme/log` for each flip

## Notes

- macOS branch unchanged — its `last=""` polling loop already seeds correctly.
- `data:0` (portal "no preference") is intentionally ignored by the seed; same goes for any unrecognised `gsettings` value. Existing behavior preserved.
- The busctl seed match pattern `"u","data":N` is anchored on the `--json=short` integer type tag so it can't false-match nested integers in the payload.