### PR TITLE
chore(claude): harden .claude/ hooks, rules, and settings

### DIFF
--- a/.claude/hooks/pre-edit-block.sh
+++ b/.claude/hooks/pre-edit-block.sh
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
-# Pre-edit guard: block vendor/lock files and secrets.d real fish files.
+# Pre-tool guard: block edits to vendor/lock/submodule files and
+# reads or edits of secrets.d fish files.
 # Receives tool input JSON on stdin.
 
-fp=$(jq -r '.tool_input.file_path // empty')
+input=$(cat)
+fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty')
 [ -z "$fp" ] && exit 0
 
+# Read-only block: secrets files must not be read — they contain credentials.
+if [ "$tool" = "Read" ]; then
+  case "$fp" in
+    */secrets.d/*.fish)
+      case "$(basename "$fp")" in
+        *.example.fish | *.fish.example) exit 0 ;;
+      esac
+      echo "BLOCKED: do not read $fp — it contains secrets. Ask the user instead." >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+# Edit/Write block: vendor, lock, submodule, and secrets files.
 case "$fp" in
   */fzf-tmux | */yarn.lock | */.yarn/*)
     echo "BLOCKED: $fp is a vendor/lock file — do not edit directly" >&2

--- a/.claude/hooks/pre-edit-block.sh
+++ b/.claude/hooks/pre-edit-block.sh
@@ -4,9 +4,11 @@
 # Receives tool input JSON on stdin.
 
 input=$(cat)
-fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
-tool=$(printf '%s' "$input" | jq -r '.tool_name // empty')
-[ -z "$fp" ] && exit 0
+if ! fp=$(printf '%s' "$input" | jq -er '.tool_input.file_path' 2> /dev/null); then
+  echo "BLOCKED: invalid hook payload (missing/invalid tool_input.file_path)" >&2
+  exit 2
+fi
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2> /dev/null)
 
 # Read-only block: secrets files must not be read — they contain credentials.
 if [ "$tool" = "Read" ]; then

--- a/.claude/hooks/pre-edit-block.sh
+++ b/.claude/hooks/pre-edit-block.sh
@@ -15,7 +15,7 @@ if [ "$tool" = "Read" ]; then
   case "$fp" in
     */secrets.d/*.fish)
       case "$(basename "$fp")" in
-        *.example.fish | *.fish.example) exit 0 ;;
+        *.fish.example) exit 0 ;;
       esac
       echo "BLOCKED: do not read $fp — it contains secrets. Ask the user instead." >&2
       exit 2
@@ -40,7 +40,7 @@ case "$fp" in
     ;;
   */secrets.d/*.fish)
     case "$(basename "$fp")" in
-      *.example.fish | *.fish.example) exit 0 ;;
+      *.fish.example) exit 0 ;;
     esac
     echo "BLOCKED: do not edit $fp directly — it is gitignored." >&2
     echo "Copy the matching .fish.example file and edit that locally." >&2

--- a/.claude/rules/bash-routing.md
+++ b/.claude/rules/bash-routing.md
@@ -1,0 +1,102 @@
+---
+description: "Shell command routing — ctx_batch_execute is the default tool for all commands producing output."
+alwaysApply: true
+---
+
+# Bash routing — ctx_batch_execute is the default
+
+ALWAYS use `mcp__plugin_context-mode_context-mode__ctx_batch_execute` for shell
+commands. The default tool for ANY shell invocation in this repo is
+`ctx_batch_execute` — `Bash` is the exception, not the rule.
+
+## The default rule
+
+If a shell command produces output you intend to read, use
+`ctx_batch_execute`. This includes:
+
+- `rg`, `fd`, `grep`, `find` — every search.
+- `shellcheck`, `shfmt --diff`, `fish_indent --check` — every lint/format check.
+- `biome check`, `yamllint`, `actionlint`, `stylua --check` — every formatter check.
+- `ruff check`, `ruff format --check` — every Python check.
+- `pre-commit run`, `yarn lint`, `yarn lint:ec`, `yarn lint:sh` — every quality gate.
+- `dfm <subcommand>` — dotfiles manager commands.
+- `git log`, `git diff`, `git diff --stat`, `git show`, `git status -s`
+  when output is more than 5 lines.
+- `ls`, `tree`, `cat`, `head`, `tail`, `wc -l` — anything reading file content
+  for analysis.
+- `which <tool>`, `<tool> --version` when probing more than one tool at once
+  — batch the probes.
+
+Even when output is short, batch related commands together: one
+`ctx_batch_execute` call with five commands costs less than five `Bash`
+calls.
+
+## When Bash is acceptable
+
+Only these narrow cases:
+
+1. **Side-effect commands that produce no output you need to read:**
+    `git add <file>`, `git commit -m '...'`, `git mv`, `git rm`,
+    `git checkout <branch>`, `git push`, `mkdir -p <dir>`, `chmod`, `chown`.
+    The exit code is the signal; the stdout is irrelevant.
+2. **In-place formatters with no output to capture:**
+    `fish_indent --write <file>`, `shfmt -w <file>`.
+3. **Package installations that must stream output interactively:**
+    `yarn install`, `yarn add <pkg>`, `brew install <pkg>`.
+4. **One-line commands the user explicitly asks for** during a
+    conversation (e.g., "run `yarn build`").
+
+If you find yourself piping through `head`, `tail`, or `grep` to truncate
+output, you should be using `ctx_batch_execute` instead. The truncation
+is a tell that the raw output is bigger than you want in chat context.
+
+## Forbidden patterns
+
+- `Bash` with `rg -n ... | head -20` — use `ctx_batch_execute` with a
+  focused `queries:` array instead.
+- Chaining many small `ctx_execute` calls — one `ctx_batch_execute` with
+  multiple `commands` and `queries` is the right shape.
+- `ctx_execute` / `ctx_execute_file` to write files — use `Write` / `Edit`.
+- `WebFetch` for documentation — use `ctx_fetch_and_index`.
+
+## Practical patterns
+
+Investigation pass — one `ctx_batch_execute`, many queries:
+
+```yaml
+commands:
+  - label: "shellcheck on changed scripts"
+    command: "shellcheck local/bin/dfm local/bin/msgr"
+  - label: "shfmt diff"
+    command: "shfmt --diff local/bin/dfm"
+  - label: "yamllint on install config"
+    command: "yamllint install.conf.yaml"
+queries:
+  - "shellcheck errors"
+  - "shfmt formatting differences"
+  - "yamllint violations"
+```
+
+Lint pass — batch the full quality gate:
+
+```yaml
+commands:
+  - label: "yarn lint"
+    command: "yarn lint"
+queries:
+  - "lint errors"
+  - "editorconfig violations"
+```
+
+Search pass — rg with follow-up:
+
+```yaml
+commands:
+  - label: "functions referencing theme apply"
+    command: "rg -n 'theme apply' config/fish/"
+  - label: "handlers list"
+    command: "ls config/theme/handlers.d/"
+queries:
+  - "theme apply callers"
+  - "handler names"
+```

--- a/.claude/rules/commit-format.md
+++ b/.claude/rules/commit-format.md
@@ -1,3 +1,8 @@
+---
+description: "Conventional Commits format for all commit messages in this repo."
+alwaysApply: true
+---
+
 # Commit messages
 
 Use Conventional Commits: `type(scope): summary`.

--- a/.claude/rules/context-mode.md
+++ b/.claude/rules/context-mode.md
@@ -1,3 +1,8 @@
+---
+description: "MCP routing rules for context window protection — curl, WebFetch, Bash, and Read tool routing."
+alwaysApply: true
+---
+
 # context-mode — mandatory routing rules
 
 context-mode MCP tools protect the context window from flooding. A
@@ -32,15 +37,11 @@ query the indexed content.
 
 ## REDIRECTED tools — use sandbox equivalents
 
-### Bash (>20 lines output)
+### Bash shell commands
 
-Bash is ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`,
-`pip install`, and other short-output commands. For everything else:
-
-- `ctx_batch_execute(commands, queries)` — run multiple commands +
-  search in ONE call
-- `ctx_execute(language: "shell", code: "...")` — run in sandbox; only
-  stdout enters context
+The authoritative Bash routing rule is in `.claude/rules/bash-routing.md`.
+`ctx_batch_execute` is the default for any command that produces output you intend to read.
+Bash is reserved for side-effect-only operations that produce no output.
 
 ### Read for analysis
 

--- a/.claude/rules/context-mode.md
+++ b/.claude/rules/context-mode.md
@@ -41,7 +41,7 @@ query the indexed content.
 
 The authoritative Bash routing rule is in `.claude/rules/bash-routing.md`.
 `ctx_batch_execute` is the default for any command that produces output you intend to read.
-Bash is reserved for side-effect-only operations that produce no output.
+See `bash-routing.md` for the complete list of allowed Bash exceptions.
 
 ### Read for analysis
 

--- a/.claude/rules/editorconfig.md
+++ b/.claude/rules/editorconfig.md
@@ -1,3 +1,8 @@
+---
+description: "EditorConfig adherence is mandatory for every file edit in this repo."
+alwaysApply: true
+---
+
 # EditorConfig adherence
 
 Every edit and every write to a tracked file in this repo must

--- a/.claude/rules/host-specific-config.md
+++ b/.claude/rules/host-specific-config.md
@@ -1,3 +1,8 @@
+---
+description: "Machine-specific config must live under hosts/<hostname>/, never in the shared config/ tree."
+alwaysApply: false
+---
+
 # Host-specific configuration
 
 Personal hostnames, SSH targets, paths under `~/Code/<your-org>/`,

--- a/.claude/rules/no-hook-bypass.md
+++ b/.claude/rules/no-hook-bypass.md
@@ -1,3 +1,8 @@
+---
+description: "Git and tool hook bypass prevention — no --no-verify or --no-gpg-sign flags."
+alwaysApply: true
+---
+
 # Never bypass project hooks
 
 Never invoke `git`, `npm`, `yarn`, `pre-commit`, or any other tool

--- a/.claude/rules/no-npm.md
+++ b/.claude/rules/no-npm.md
@@ -1,3 +1,8 @@
+---
+description: "Package manager constraint: yarn v4+ only, never npm."
+alwaysApply: true
+---
+
 # Package manager
 
 Use `yarn` (v4+), never `npm`.

--- a/.claude/rules/no-schema-guessing.md
+++ b/.claude/rules/no-schema-guessing.md
@@ -28,7 +28,7 @@ key names:
 
 ## What is required instead
 
-Before writing any key or value in a schema-less file, exactly one of the
+Before writing any key or value in a schema-less file, at least one of the
 following must be true:
 
 1. **Docs fetched in this session**: call `ctx_fetch_and_index` on the

--- a/.claude/rules/no-schema-guessing.md
+++ b/.claude/rules/no-schema-guessing.md
@@ -1,0 +1,75 @@
+---
+description: "Key-name guessing in schema-less or unvalidated config files is strictly prohibited."
+alwaysApply: true
+---
+
+# No guessing without a schema
+
+When editing any structured config file (YAML, JSON, TOML, INI, or any
+key-value format) that has no JSON Schema **and** no linter that validates
+key names:
+
+**You must not guess, assume, infer, or extrapolate any key name or value.**
+
+## What counts as guessing (all forbidden)
+
+- **Sibling-key extrapolation**: "the adjacent key uses format X, so this
+  one probably does too"
+- **Cross-tool carry-over**: applying schema knowledge from a different
+  tool's config file (e.g., using a plugin's frontmatter key in Claude
+  Code's own frontmatter)
+- **Training-data recall**: recalling from model weights — weights encode
+  a past snapshot and may not match the current schema
+- **Inferred docs**: "the docs URL structure suggests the key is named X"
+  without fetching and reading the actual page
+- **Unverified repo examples**: copying a key name from a file in this repo
+  without confirming that file targets the same tool, the same config
+  namespace, and a version of the schema that matches what is installed
+
+## What is required instead
+
+Before writing any key or value in a schema-less file, exactly one of the
+following must be true:
+
+1. **Docs fetched in this session**: call `ctx_fetch_and_index` on the
+    tool's official reference page and quote the exact key from the returned
+    content. A previous session's fetch does not count — fetch again.
+2. **Tool's own help output**: run `<tool> --help`, `<tool> schema`, or
+    equivalent via `ctx_batch_execute` and quote the key from that output.
+3. **User-provided key name**: the user typed or pasted the key name in
+    this session.
+4. **Tool-reported error**: the tool itself printed the correct key name in
+    an error message visible in the current session's output.
+
+"It looks right" is not evidence. "I've seen this before" is not evidence.
+"The sibling key uses this pattern" is not evidence.
+
+## Why syntax linters are not sufficient
+
+yamllint, biome, and prettier validate **syntax and formatting only** — they
+do not check whether a key name is recognised by the tool that reads the
+file. A file where every key is misspelled can pass yamllint with no
+errors. "The linter passed" never implies "the key names are correct."
+
+This distinction is why `validate-config-schemas.md` falls back to yamllint
+for schema-less files: yamllint catches syntax errors. It does NOT authorise
+guessing key names. Both rules apply simultaneously.
+
+## Canonical failure mode (N-078, 2026-05-18)
+
+Claude Code's `.claude/rules/` frontmatter has no JSON schema. v8r returns
+"no schema found". yamllint does not check frontmatter keys. Training data
+recalled `globs:` (used by the context-mode superpowers plugin) and it was
+applied to seven Claude Code rule files. The Claude Code docs use `paths:`.
+All seven files required correction; an Invalid finding was filed.
+
+Correct procedure: call `ctx_fetch_and_index` on `code.claude.com/docs/en/memory`,
+search for "path-specific rules", quote `paths:` from the returned text.
+
+## Relationship to validate-config-schemas.md
+
+- File **has** a schema (`v8r` finds one) → run `yarn dlx v8r <file>` per
+  `validate-config-schemas.md`. This rule still applies during writing; v8r
+  is the commit-time gate.
+- File **has no** schema → this rule is the only safety net. No commit-time
+  gate exists. The discipline is the safety net.

--- a/.claude/rules/posix-scripts.md
+++ b/.claude/rules/posix-scripts.md
@@ -1,3 +1,13 @@
+---
+description: "POSIX script validation — validate with sh -n not bash -n for these five scripts."
+paths:
+  - "local/bin/x-ssh-audit"
+  - "local/bin/x-codeql"
+  - "local/bin/x-until-error"
+  - "local/bin/x-until-success"
+  - "local/bin/x-ssl-expiry-date"
+---
+
 # POSIX shell scripts
 
 Validate POSIX shell scripts with `sh -n`, never `bash -n`.

--- a/.claude/rules/secrets-files.md
+++ b/.claude/rules/secrets-files.md
@@ -1,3 +1,9 @@
+---
+description: "Fish secrets in secrets.d must never be committed or read directly — edit example files only."
+paths:
+  - "config/fish/secrets.d/**"
+---
+
 # Fish secrets
 
 Never commit anything under `config/fish/secrets.d/` except `*.example`

--- a/.claude/rules/validate-config-schemas.md
+++ b/.claude/rules/validate-config-schemas.md
@@ -1,3 +1,12 @@
+---
+description: "Run v8r schema validation before committing any structured config file change."
+paths:
+  - "**/*.yml"
+  - "**/*.yaml"
+  - "**/*.json"
+  - "**/*.toml"
+---
+
 # Validate config schemas before guessing keys
 
 When adding or changing a key in any structured-config file (YAML,
@@ -32,8 +41,11 @@ committing.
 | `install.conf.yaml` (Dotbot)                   | `dotbot-validate` skill                |
 | Generic YAML without a schema                  | `yamllint` (already in pre-commit)     |
 
-If `v8r` says "no schema found", the file is not schema-backed — fall
-back to the project's existing linter (yamllint, biome, ruff, …).
+If `v8r` says "no schema found", the file is not schema-backed — run the
+project's existing syntax linter (yamllint, biome, ruff, …) to catch
+formatting errors. Key-name guessing is still strictly prohibited; see
+`no-schema-guessing.md` for what evidence is required before writing any
+key name into a schema-less file.
 
 ## When extrapolation is fine
 

--- a/.claude/rules/vendored-files.md
+++ b/.claude/rules/vendored-files.md
@@ -1,3 +1,14 @@
+---
+description: "Vendored fzf files must never be modified — update via submodule sync only."
+paths:
+  - "local/bin/fzf-tmux"
+  - "config/fzf/completion.bash"
+  - "config/fzf/completion.zsh"
+  - "config/fzf/key-bindings.bash"
+  - "config/fzf/key-bindings.zsh"
+  - "config/fzf/key-bindings.fish"
+---
+
 # Vendored files
 
 Never modify these files — they are vendored verbatim from

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "permissions": {
-    "deny": ["Bash(curl:*)", "Bash(wget:*)", "WebFetch(*)"]
+    "deny": ["Bash(curl:*)", "Bash(wget:*)", "WebFetch"]
   },
   "hooks": {
     "SessionStart": [
@@ -16,7 +16,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|Read",
+        "matcher": "Edit|Write|Read|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "permissions": {
+    "deny": ["Bash(curl:*)", "Bash(wget:*)", "WebFetch(*)"]
+  },
   "hooks": {
     "SessionStart": [
       {
@@ -13,7 +16,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|Read",
         "hooks": [
           {
             "type": "command",

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -6,6 +6,7 @@ config/op/plugins/used_plugins/*
 config/vim/*
 docs/*
 local/bin/asdf/*
+local/md/*
 node_modules/*
 tools/*
 # Code-review export pasted from GitHub PR comments — not authored here.

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -2,8 +2,10 @@
 
 Generated: 2026-04-26
 Last validated: 2026-05-18
-Pass 12 applied: 2026-05-18
-Scope of latest round (Pass 12): PR-review pass — rebased on origin/main; addressed all
+Pass 13 applied: 2026-05-18
+Scope of latest round (Pass 13): Follow-up security fix — `*.example.fish` bypass in
+pre-edit-block.sh. Fixed 1 (N-086).
+Scope of previous round (Pass 12): PR-review pass — rebased on origin/main; addressed all
 Copilot and CodeRabbitAI comments on chore/claude-rules. Fixed 5 (N-081..N-085). No open
 findings remain.
 Scope of previous round (Pass 11): Closed N-080 — `validate-config-schemas.md` guessing loophole.
@@ -46,8 +48,9 @@ tests, and CI. Filed and fixed 7 new defects (N-023..N-029). Recorded
 
 ## Summary
 
-- Total: 82 | Open: 0 | Fixed: 70 | Advisory: 3 | Invalid: 9
+- Total: 83 | Open: 0 | Fixed: 71 | Advisory: 3 | Invalid: 9
 
+Pass 13 (2026-05-18): Filed and fixed N-086 — `*.example.fish` bypass in pre-edit-block.sh.
 Pass 12 (2026-05-18): PR-review pass (chore/claude-rules). Fixed 5 (N-081..N-085): fail-closed
 jq parsing in pre-edit-block.sh, MultiEdit gap in PreToolUse matcher, over-constrained "exactly
 one" in no-schema-guessing.md, conflicting Bash summary in context-mode.md, invalid
@@ -86,6 +89,22 @@ carry the current date, not the original tag date. A comment was added to docume
 the limitation. Full fix requires passing the tag date from the calling workflow.
 
 ## Fixed
+
+### Pass 13 — 2026-05-18
+
+#### [N-086] `pre-edit-block.sh` `*.example.fish` exception allows secrets bypass
+
+Category: security
+Area: `.claude/hooks/pre-edit-block.sh`
+Fixed: 2026-05-18
+Notes: Both the Read block (line 18) and Edit/Write block (line 43) contained the
+exception `*.example.fish | *.fish.example`. The `*.example.fish` half matches any
+file ending in `.example.fish` — e.g., `prod.example.fish` in `secrets.d/`, which
+fish auto-sources as a `*.fish` file and which `.gitignore` treats as a secret. That
+file would pass the exception and be readable/editable despite containing credentials.
+The tracked example naming convention is `*.fish.example` only (e.g.,
+`github.fish.example`). Removed `*.example.fish |` from both case branches so only
+`*.fish.example` files are exempted. Copilot report PR #376 r3262054215.
 
 ### Pass 12 — 2026-05-18
 

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -2,12 +2,16 @@
 
 Generated: 2026-04-26
 Last validated: 2026-05-18
-Pass 10 applied: 2026-05-18
-Scope of latest round (Pass 10): `.claude/` hardening — hooks, rules, skills, agents, and
+Pass 12 applied: 2026-05-18
+Scope of latest round (Pass 12): PR-review pass — rebased on origin/main; addressed all
+Copilot and CodeRabbitAI comments on chore/claude-rules. Fixed 5 (N-081..N-085). No open
+findings remain.
+Scope of previous round (Pass 11): Closed N-080 — `validate-config-schemas.md` guessing loophole.
+Fixed 1 (N-080). No open findings remain.
+Scope of previous round (Pass 10): `.claude/` hardening — hooks, rules, skills, agents, and
 settings audited against the official hooks reference. New findings: context-mode npm→yarn fix,
 Read-tool secrets blocking, rules frontmatter, settings.json permission enforcement.
-Fixed 3 (N-072..N-074); filed 3 Open requiring user action on protected files (N-075..N-077);
-1 Advisory (N-078). No prior open findings to re-validate.
+Fixed 8 (N-072..N-077, N-079); 1 Invalid (N-078). No prior open findings to re-validate.
 Scope of previous round (Pass 9): `config/exports` shellcheck source-following and
 rules/audit-findings lint false-positive fixes.
 Scope of previous round (Pass 6): focused audit of sesh configuration —
@@ -42,8 +46,12 @@ tests, and CI. Filed and fixed 7 new defects (N-023..N-029). Recorded
 
 ## Summary
 
-- Total: 77 | Open: 0 | Fixed: 65 | Advisory: 3 | Invalid: 9
+- Total: 82 | Open: 0 | Fixed: 70 | Advisory: 3 | Invalid: 9
 
+Pass 12 (2026-05-18): PR-review pass (chore/claude-rules). Fixed 5 (N-081..N-085): fail-closed
+jq parsing in pre-edit-block.sh, MultiEdit gap in PreToolUse matcher, over-constrained "exactly
+one" in no-schema-guessing.md, conflicting Bash summary in context-mode.md, invalid
+`WebFetch(*)` deny entry in settings.json.
 Pass 11 (2026-05-18): Filed and fixed N-080 — `validate-config-schemas.md` fallback line
 implied yamllint suffices for schema-less files; new rule `no-schema-guessing.md` codifies
 that key-name guessing is prohibited when no schema or key-name validator exists.
@@ -78,6 +86,49 @@ carry the current date, not the original tag date. A comment was added to docume
 the limitation. Full fix requires passing the tag date from the calling workflow.
 
 ## Fixed
+
+### Pass 12 — 2026-05-18
+
+#### [N-081] `pre-edit-block.sh` exits 0 on malformed JSON hook payload
+
+Fixed: 2026-05-18
+Notes: `jq -r '.tool_input.file_path // empty'` returned empty string and exit 0 on
+malformed JSON input, so the hook allowed all subsequent blocking logic to be bypassed.
+Replaced with `jq -er '.tool_input.file_path'` inside `if !`; the hook now exits 2 with
+a BLOCKED message when the payload is missing `tool_input.file_path` or is not valid JSON.
+CodeRabbitAI report on PR #376.
+
+#### [N-082] `MultiEdit` not included in PreToolUse file-guard matcher
+
+Fixed: 2026-05-18
+Notes: `settings.json` matcher was `Edit|Write|Read`, leaving `MultiEdit` (which also
+carries `file_path`) outside the `pre-edit-block.sh` guard. Vendor, submodule, and secrets
+edit blocks could be bypassed via MultiEdit. Matcher updated to `Edit|Write|Read|MultiEdit`.
+Copilot report on PR #376.
+
+#### [N-083] `no-schema-guessing.md` "exactly one" over-constrains valid multi-evidence cases
+
+Fixed: 2026-05-18
+Notes: "Before writing any key … exactly one of the following must be true" made the rule
+logically unsatisfiable when two sources corroborated the same key (e.g., user-provided key
+also confirmed by fetched docs). Changed to "at least one". Copilot report on PR #376.
+
+#### [N-084] `context-mode.md` Bash summary contradicts `bash-routing.md`
+
+Fixed: 2026-05-18
+Notes: "Bash is reserved for side-effect-only operations that produce no output" conflicted
+with bash-routing.md, which also permits in-place formatters, streaming package installs,
+and one-line user-requested commands. Replaced the summary sentence with "See
+`bash-routing.md` for the complete list of allowed Bash exceptions." Copilot report on PR #376.
+
+#### [N-085] `settings.json` `"WebFetch(*)"` fails v8r schema pattern
+
+Fixed: 2026-05-18
+Notes: The schemastore pattern for deny entries requires the parenthetical argument to
+contain at least one character that is not `)`, `*`, or `?` (lookahead `(?=.*[^)*?])`).
+`WebFetch(*)` contains only `*` as the argument, so the lookahead fails. Changed to `"WebFetch"`
+(no parens), which matches the bare-tool-name branch and denies all WebFetch calls. v8r now
+reports `.claude/settings.json is valid`.
 
 ### Pass 11 — 2026-05-18
 

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -1,9 +1,16 @@
 # Nitpicker Findings
 
 Generated: 2026-04-26
-Last validated: 2026-05-05
-Pass 6 fixes applied: 2026-05-05
-Scope of latest round (Pass 6): focused audit of sesh configuration —
+Last validated: 2026-05-18
+Pass 10 applied: 2026-05-18
+Scope of latest round (Pass 10): `.claude/` hardening — hooks, rules, skills, agents, and
+settings audited against the official hooks reference. New findings: context-mode npm→yarn fix,
+Read-tool secrets blocking, rules frontmatter, settings.json permission enforcement.
+Fixed 3 (N-072..N-074); filed 3 Open requiring user action on protected files (N-075..N-077);
+1 Advisory (N-078). No prior open findings to re-validate.
+Scope of previous round (Pass 9): `config/exports` shellcheck source-following and
+rules/audit-findings lint false-positive fixes.
+Scope of previous round (Pass 6): focused audit of sesh configuration —
 `config/sesh/sesh.toml`, `config/tmux/sesh.sh`, and
 `config/fish/completions/sesh.fish`. Re-validated prior open findings (0
 real-Open at entry; N-013/N-020/N-056 remain under Advisory). Filed 7
@@ -35,8 +42,16 @@ tests, and CI. Filed and fixed 7 new defects (N-023..N-029). Recorded
 
 ## Summary
 
-- Total: 68 | Open: 0 | Fixed: 57 | Advisory: 3 | Invalid: 8
+- Total: 77 | Open: 0 | Fixed: 65 | Advisory: 3 | Invalid: 9
 
+Pass 11 (2026-05-18): Filed and fixed N-080 — `validate-config-schemas.md` fallback line
+implied yamllint suffices for schema-less files; new rule `no-schema-guessing.md` codifies
+that key-name guessing is prohibited when no schema or key-name validator exists.
+Pass 10 (2026-05-18): `.claude/` hardening — fixed npm loophole in context-mode.md (N-072),
+added secrets-read blocking to pre-edit-block.sh (N-073), frontmatter to all 14 rules files
+(N-074, N-077), Read to PreToolUse matcher (N-075), permissions.deny to settings.json (N-076).
+All 6 criteria satisfied. Filed N-078 (Invalid — `paths:` is correct per official docs). Filed
+and fixed N-079: 4 rule files added in Pass 10 used `globs:` instead of `paths:`.
 Pass 8 (2026-05-05): closed N-068 by running the four prerequisite
 audit skills (`arch-detector`, `arch-auditor`, `security-auditor`,
 `doc-auditor`); also fixed N-069 (still-open issue triaged from
@@ -63,6 +78,72 @@ carry the current date, not the original tag date. A comment was added to docume
 the limitation. Full fix requires passing the tag date from the calling workflow.
 
 ## Fixed
+
+### Pass 11 — 2026-05-18
+
+#### [N-080] `validate-config-schemas.md` fallback implied yamllint suffices; key-name guessing loophole open
+Fixed: 2026-05-18
+Notes: The fallback line "fall back to the project's existing linter (yamllint, biome,
+ruff, …)" implied that a passing syntax linter permitted proceeding without evidence for
+key names. yamllint validates syntax, not key names. Created `no-schema-guessing.md`
+to prohibit all forms of guessing/extrapolation for schema-less files and to define the
+four acceptable evidence sources (fetched docs, tool help output, user-provided key,
+tool error message). Updated the fallback line in `validate-config-schemas.md` to
+cross-reference `no-schema-guessing.md` explicitly. Canonical failure mode: N-078.
+
+### Pass 10 — 2026-05-18
+
+#### [N-072] `context-mode.md` listed `npm install` and `pip install` as acceptable Bash
+Fixed: 2026-05-18
+Notes: `.claude/rules/context-mode.md` line 37-38 declared `npm install` and `pip install`
+as acceptable Bash commands. `npm` is explicitly prohibited by `no-npm.md`; `pip install` has
+no role in this repo's tool management (mise handles Python). Changed to `yarn install,
+brew install` — the two package install commands that belong in Bash per no-npm.md and
+bash-routing.md. Verified with `grep npm .claude/rules/context-mode.md` → no results.
+
+#### [N-073] `pre-edit-block.sh` did not block Read tool on secrets files
+Fixed: 2026-05-18
+Notes: The hook only guarded `Edit|Write` operations. The `Read` tool could read any file
+under `config/fish/secrets.d/` without interception. Updated `pre-edit-block.sh` to:
+(a) buffer stdin with `input=$(cat)` so `tool_name` and `file_path` can both be extracted,
+(b) detect `tool == "Read"` and apply a secrets-only block with an appropriate message
+("do not read … it contains secrets"), (c) skip the vendor/submodule blocks for Read (those
+files are readable, just not editable). Verified: `shellcheck` clean, `editorconfig-checker`
+clean. Note: the hook fires only when settings.json matcher includes `Read` — see N-075.
+
+#### [N-074] Eight rules files lacked YAML frontmatter
+Fixed: 2026-05-18
+Notes: Added frontmatter to `bash-routing.md` (alwaysApply), `context-mode.md` (alwaysApply),
+`no-npm.md` (alwaysApply), `editorconfig.md` (alwaysApply), `host-specific-config.md`,
+`posix-scripts.md` (globs for 5 POSIX scripts), `secrets-files.md` (globs for secrets.d),
+`vendored-files.md` (globs for vendored fzf files). Remaining 3 files resolved under N-077.
+
+#### [N-075] `settings.json` PreToolUse matcher excluded Read — secrets-read block inert
+Fixed: 2026-05-18
+Notes: Changed `"Edit|Write"` to `"Edit|Write|Read"` in the PreToolUse hook matcher in
+`.claude/settings.json`. The pre-edit-block.sh Read-blocking logic was already in place
+(N-073); this change activates it. Verified: matcher now reads `"Edit|Write|Read"`.
+
+#### [N-076] `settings.json` had no `permissions.deny` — curl/WebFetch unrestricted at permission layer
+Fixed: 2026-05-18
+Notes: Added `"permissions": {"deny": ["Bash(curl:*)", "Bash(wget:*)", "WebFetch(*)"]}` to
+`.claude/settings.json`. These three denies enforce at the permission layer what `context-mode.md`
+and `bash-routing.md` mandate at the instruction layer. Project-level deny overrides the global
+`~/.claude/settings.json` allow entries for curl and WebFetch domains.
+
+#### [N-077] Two rules files lacked frontmatter — `commit-format.md`, `validate-config-schemas.md`
+Fixed: 2026-05-18
+Notes: `no-hook-bypass.md` was fixed in an earlier Write attempt in this pass (alwaysApply: true).
+`commit-format.md` (alwaysApply: true) and `validate-config-schemas.md` (paths for yml/yaml/json/toml)
+were fixed after the user switched from auto-mode, which unblocked the self-modification guard.
+All 14 rules files now have YAML frontmatter.
+
+#### [N-079] Four rules files added in Pass 10 used `globs:` — correct key is `paths:`
+Fixed: 2026-05-18
+Notes: `posix-scripts.md`, `secrets-files.md`, `vendored-files.md`, and
+`validate-config-schemas.md` were written with `globs:` as the file-scoping frontmatter key.
+Official docs (`code.claude.com/docs/en/memory`) confirm the correct key is `paths:`. Renamed
+in all four files. Also corrected the erroneous `globs:` mention in N-077 notes.
 
 ### Pass 9 — 2026-05-05
 
@@ -328,6 +409,15 @@ to avoid colliding with the standard `TMPDIR` env var). Bats guarantees
 `teardown()` runs even on assertion failure.
 
 ## Invalid
+
+### Pass 10 — 2026-05-18
+
+#### [N-078] Three existing rule files use `paths:` frontmatter key — correct key is `globs:`
+Notes: Premise wrong. Official Claude Code docs (`code.claude.com/docs/en/memory`,
+"Path-specific rules" section) use `paths:` as the correct YAML frontmatter key for
+file-scoped rules. The three files (`shell-scripts.md`, `keymap-descriptions.md`,
+`lsp-list-parity.md`) were already correct. The finding was filed based on a mistaken
+belief that `globs:` (used by the context-mode superpowers plugin) was the schema key.
 
 ### Pass 6 — 2026-05-05
 

--- a/local/bin/gh-set-profile.md
+++ b/local/bin/gh-set-profile.md
@@ -4,7 +4,7 @@ Auto-apply a git profile based on the current repository's path.
 
 ## Usage
 
-```
+```sh
 gh-set-profile
 ```
 


### PR DESCRIPTION
## Summary

- **New rules**: `bash-routing.md` (ctx_batch_execute as default for all output-producing shell commands) and `no-schema-guessing.md` (prohibits key-name guessing in schema-less config files)
- **Frontmatter**: All 14 `.claude/rules/` files now have YAML frontmatter (`description` + `alwaysApply` or `paths`); fixed `globs:` → `paths:` in 7 files (official docs confirm `paths:` is the correct Claude Code schema key)
- **Hook**: `pre-edit-block.sh` now blocks the `Read` tool on `secrets.d/*.fish` files, not only `Edit`/`Write`
- **Settings**: Added `permissions.deny` for `Bash(curl:*)`, `Bash(wget:*)`, `WebFetch(*)`; expanded `PreToolUse` matcher to include `Read`
- **Content fixes**: `context-mode.md` npm/pip loophole removed; `validate-config-schemas.md` fallback clarified — yamllint validates syntax only, not key names

## Motivation

Six criteria from a nitpicker audit (`/nitpicker`):
1. All hooks follow the official hooks reference
2. No loopholes in hooks, rules, skills, or agents
3. All rules have appropriate frontmatter
4. Rules are non-overlapping unless strictly beneficial
5. Hooks block all attempts to read secrets files
6. `settings.json` enforces what rules prohibit

## Test plan

- [ ] `pre-commit run --all-files` passes on the branch
- [ ] `yarn lint` (stop-gate) passes
- [ ] Read on `config/fish/secrets.d/*.fish` is blocked with a clear message
- [ ] Read on `config/fish/secrets.d/*.example.fish` is allowed
- [ ] `curl` and `WebFetch` are denied at the permission layer
- [ ] All `.claude/rules/*.md` files have YAML frontmatter visible in `head -5`