### PR TITLE
feat(dfm): add secrets management subcommands (create/list/show/remove)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.socket
 *.swp
 *.old
+*.sql
 *cache
 .env
 .idea

--- a/config/fish/secrets.d/README.md
+++ b/config/fish/secrets.d/README.md
@@ -24,7 +24,19 @@ This directory contains sensitive environment variables like API tokens and cred
 
 ## Adding New Secret Files
 
-Create a new `.fish` file in this directory with your environment variables:
+The easiest way is `dfm secrets create`, which prompts for the value without echoing it and writes both the
+fish file here and the matching bash/zsh file under `config/secrets.d/`, each with `0600` permissions:
+
+```sh
+# Filename is derived from the env name (GITHUB_TOKEN -> github):
+dfm secrets create GITHUB_TOKEN
+
+# Or pass an explicit filename when the derived one doesn't fit
+# (SONAR_TOKEN is conventionally stored as sonarcloud):
+dfm secrets create SONAR_TOKEN sonarcloud
+```
+
+Or create a `.fish` file in this directory by hand with your environment variables:
 
 ```fish
 # Example: openai.fish

--- a/config/fish/secrets.d/README.md
+++ b/config/fish/secrets.d/README.md
@@ -43,6 +43,14 @@ Or create a `.fish` file in this directory by hand with your environment variabl
 set -x OPENAI_API_KEY "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
+## Managing Secrets
+
+```sh
+dfm secrets list           # list configured secrets (names + env vars, no values)
+dfm secrets show github    # print a secret's contents (reveals the value)
+dfm secrets remove github  # delete a secret's fish + bash/zsh files (asks first)
+```
+
 Common secret patterns:
 
 - `github.fish` - GitHub Personal Access Token (`GITHUB_TOKEN`)

--- a/local/bin/dfm
+++ b/local/bin/dfm
@@ -905,6 +905,15 @@ secrets_filename_from_env()
   printf '%s' "$name"
 }
 
+# True when NAME is a safe secrets filename. It must start with an
+# alphanumeric and contain only letters, digits, '.', '_' or '-'. This
+# rejects empty names, '.'/'..', leading-dot names (which would create a
+# hidden file the listing glob skips) and anything with a path separator.
+secrets_valid_name()
+{
+  [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+}
+
 # Create fish + bash/zsh secrets files for an environment variable.
 # Usage: secrets_create <ENV_NAME> [filename]
 # The value is read from a hidden prompt so it never reaches the
@@ -930,11 +939,17 @@ secrets_create()
 
   [[ -z "$filename" ]] && filename=$(secrets_filename_from_env "$env_name")
 
-  # Guard against empty or path-traversing filenames so the secret can
-  # only ever land inside the two secrets.d directories.
-  if [[ ! "$filename" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  # Stripping a suffix can leave nothing (e.g. env name "_TOKEN").
+  if [[ -z "$filename" ]]; then
+    msgr err "Could not derive a filename from '$env_name' — pass one explicitly"
+    return 1
+  fi
+
+  # Guard the filename so the secret can only land inside the two
+  # secrets.d directories, never as a traversal path or hidden file.
+  if ! secrets_valid_name "$filename"; then
     msgr err "Invalid secrets filename: $filename"
-    msgr nested "Allowed characters: letters, digits, '.', '_', '-'"
+    msgr nested "Use letters, digits, '.', '_', '-'; must start alphanumeric"
     return 1
   fi
 
@@ -954,8 +969,6 @@ secrets_create()
     return 1
   fi
 
-  mkdir -p "$(dirname "$fish_secret")" "$(dirname "$sh_secret")"
-
   # Store the value single-quoted so secrets containing $, ", \, or
   # backticks are written verbatim instead of being expanded or
   # breaking the file. Each shell has different single-quote rules:
@@ -966,9 +979,12 @@ secrets_create()
   fish_value=${secret//\\/\\\\}
   fish_value=${fish_value//\'/\\\'}
 
+  # Create the directories and files under a 077 umask so both the
+  # secrets.d directories (0700) and the files (0600) are owner-only.
   local old_umask
   old_umask=$(umask)
   umask 077
+  mkdir -p "$(dirname "$fish_secret")" "$(dirname "$sh_secret")"
   printf "# %s\nset -x %s '%s'\n" "$env_name" "$env_name" "$fish_value" > "$fish_secret"
   printf "# %s\nexport %s='%s'\n" "$env_name" "$env_name" "$sh_value" > "$sh_secret"
   umask "$old_umask"
@@ -1060,7 +1076,7 @@ secrets_show()
     return 1
   fi
 
-  if [[ ! "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  if ! secrets_valid_name "$name"; then
     msgr err "Invalid secrets name: $name"
     return 1
   fi
@@ -1094,7 +1110,7 @@ secrets_remove()
     return 1
   fi
 
-  if [[ ! "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  if ! secrets_valid_name "$name"; then
     msgr err "Invalid secrets name: $name"
     return 1
   fi

--- a/local/bin/dfm
+++ b/local/bin/dfm
@@ -84,8 +84,18 @@
 #USAGE   cmd "msgr" help="Show all msgr message types"
 #USAGE   cmd "params" help="List all parameters"
 #USAGE }
-#USAGE cmd "secrets" help="Create shell secrets files" {
-#USAGE   cmd "create" help="Create secrets for an env var: create <ENV_NAME> [filename]"
+#USAGE cmd "secrets" help="Manage shell secrets files" {
+#USAGE   cmd "create" help="Create secrets for an env var" {
+#USAGE     arg "<env_name>" help="Environment variable name, e.g. GITHUB_TOKEN"
+#USAGE     arg "[filename]" help="Secrets filename (derived from env name if omitted)"
+#USAGE   }
+#USAGE   cmd "list" help="List configured secrets"
+#USAGE   cmd "show" help="Show a secret's contents" {
+#USAGE     arg "<name>" help="Secret name (filename without extension)"
+#USAGE   }
+#USAGE   cmd "remove" help="Remove a secret" {
+#USAGE     arg "<name>" help="Secret name (filename without extension)"
+#USAGE   }
 #USAGE   cmd "github" help="Create GITHUB_TOKEN secrets for all shells"
 #USAGE }
 #USAGE cmd "cleanup" help="Remove old installs, caches, and unused packages" {
@@ -968,13 +978,169 @@ secrets_create()
   msgr nested "bash/zsh: $sh_secret"
 }
 
-# Handle secrets creation commands
+# Print the environment variable name(s) defined across the given secret
+# files, comma-separated and de-duplicated, WITHOUT revealing any values.
+secrets_env_names()
+{
+  local file line name out=""
+  for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    while IFS= read -r line; do
+      name=""
+      case "$line" in
+        "set -x "*)
+          name=${line#set -x }
+          name=${name%% *}
+          ;;
+        "export "*)
+          name=${line#export }
+          name=${name%%=*}
+          ;;
+        *) continue ;;
+      esac
+      [[ -z "$name" ]] && continue
+      case ",$out," in
+        *",$name,"*) ;;
+        *) out="${out:+$out,}$name" ;;
+      esac
+    done < "$file"
+  done
+  printf '%s' "$out"
+}
+
+# List configured secrets: one row per name with the env var(s) it defines
+# and which shells have a file. Values are never printed.
+secrets_list()
+{
+  local fish_dir="$DOTFILES/config/fish/secrets.d"
+  local sh_dir="$DOTFILES/config/secrets.d"
+
+  local -A names=()
+  local f base
+  for f in "$fish_dir"/*.fish; do
+    [[ -e "$f" ]] || continue
+    base=$(basename "$f" .fish)
+    names["$base"]=1
+  done
+  for f in "$sh_dir"/*.sh; do
+    [[ -e "$f" ]] || continue
+    base=$(basename "$f" .sh)
+    names["$base"]=1
+  done
+
+  if [[ ${#names[@]} -eq 0 ]]; then
+    msgr msg "No secrets configured"
+    return 0
+  fi
+
+  local -a sorted
+  mapfile -t sorted < <(printf '%s\n' "${!names[@]}" | sort)
+
+  msgr msg "Configured secrets:"
+  local name fish_file sh_file shells env_names
+  for name in "${sorted[@]}"; do
+    fish_file="$fish_dir/$name.fish"
+    sh_file="$sh_dir/$name.sh"
+    shells=""
+    [[ -f "$fish_file" ]] && shells="fish"
+    [[ -f "$sh_file" ]] && shells="${shells:+$shells,}sh"
+    env_names=$(secrets_env_names "$fish_file" "$sh_file")
+    msgr nested "$(printf '%-20s %-24s [%s]' "$name" "${env_names:-?}" "$shells")"
+  done
+}
+
+# Show the contents of a secret's files. This intentionally reveals the
+# stored value — it is the user inspecting their own secret.
+secrets_show()
+{
+  local name="$1"
+
+  if [[ -z "$name" ]]; then
+    msgr err "Usage: $SCRIPT secrets show <name>"
+    return 1
+  fi
+
+  if [[ ! "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    msgr err "Invalid secrets name: $name"
+    return 1
+  fi
+
+  local fish_file="$DOTFILES/config/fish/secrets.d/$name.fish"
+  local sh_file="$DOTFILES/config/secrets.d/$name.sh"
+
+  if [[ ! -f "$fish_file" ]] && [[ ! -f "$sh_file" ]]; then
+    msgr err "No secret named '$name'"
+    msgr nested "Run '$SCRIPT secrets list' to see configured secrets"
+    return 1
+  fi
+
+  local f line
+  for f in "$fish_file" "$sh_file"; do
+    [[ -f "$f" ]] || continue
+    msgr msg "$f"
+    while IFS= read -r line; do
+      msgr nested "$line"
+    done < "$f"
+  done
+}
+
+# Remove a secret's fish + bash/zsh files after confirmation.
+secrets_remove()
+{
+  local name="$1"
+
+  if [[ -z "$name" ]]; then
+    msgr err "Usage: $SCRIPT secrets remove <name>"
+    return 1
+  fi
+
+  if [[ ! "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    msgr err "Invalid secrets name: $name"
+    return 1
+  fi
+
+  local fish_file="$DOTFILES/config/fish/secrets.d/$name.fish"
+  local sh_file="$DOTFILES/config/secrets.d/$name.sh"
+
+  local -a targets=()
+  [[ -f "$fish_file" ]] && targets+=("$fish_file")
+  [[ -f "$sh_file" ]] && targets+=("$sh_file")
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    msgr err "No secret named '$name'"
+    return 1
+  fi
+
+  msgr warn "About to remove:"
+  local t
+  for t in "${targets[@]}"; do
+    msgr nested "$t"
+  done
+
+  local answer
+  read -rp "Remove these files? [y/N] " answer
+  case "$answer" in
+    [yY] | [yY][eE][sS])
+      rm -f "${targets[@]}"
+      msgr yay "Removed secret '$name'"
+      ;;
+    *)
+      msgr msg "Aborted — nothing removed"
+      return 0
+      ;;
+  esac
+}
+
+# Handle secrets management commands
 section_secrets()
 {
   USAGE_PREFIX="$SCRIPT secrets <command>"
 
   MENU=(
     "create:Create secrets for an env var: create <ENV_NAME> [filename]"
+    "list:List configured secrets"
+    "show:Show a secret's contents: show <name>"
+    "remove:Remove a secret: remove <name>"
     "github:Create GITHUB_TOKEN secrets for all shells"
   )
 
@@ -982,6 +1148,18 @@ section_secrets()
     create)
       shift
       secrets_create "$@"
+      ;;
+
+    list) secrets_list ;;
+
+    show)
+      shift
+      secrets_show "$@"
+      ;;
+
+    remove)
+      shift
+      secrets_remove "$@"
       ;;
 
     github) secrets_create GITHUB_TOKEN github ;;

--- a/local/bin/dfm
+++ b/local/bin/dfm
@@ -960,8 +960,10 @@ secrets_create()
     msgr warn "Secrets files already exist — they will be overwritten"
   fi
 
+  # IFS= preserves leading/trailing whitespace and -r preserves
+  # backslashes, so the secret is captured exactly as typed.
   local secret
-  read -rsp "Enter $env_name (input hidden): " secret
+  IFS= read -rsp "Enter $env_name (input hidden): " secret
   echo
 
   if [[ -z "$secret" ]]; then
@@ -979,14 +981,28 @@ secrets_create()
   fish_value=${secret//\\/\\\\}
   fish_value=${fish_value//\'/\\\'}
 
-  # Create the directories and files under a 077 umask so both the
-  # secrets.d directories (0700) and the files (0600) are owner-only.
+  # Create the directories and files under a 077 umask so newly created
+  # paths are owner-only from the start. Every write is checked so a
+  # failure (e.g. full disk) is a hard error, never a silent success.
   local old_umask
   old_umask=$(umask)
   umask 077
-  mkdir -p "$(dirname "$fish_secret")" "$(dirname "$sh_secret")"
-  printf "# %s\nset -x %s '%s'\n" "$env_name" "$env_name" "$fish_value" > "$fish_secret"
-  printf "# %s\nexport %s='%s'\n" "$env_name" "$env_name" "$sh_value" > "$sh_secret"
+  if ! mkdir -p "$(dirname "$fish_secret")" "$(dirname "$sh_secret")" \
+    || ! printf "# %s\nset -x %s '%s'\n" "$env_name" "$env_name" "$fish_value" > "$fish_secret" \
+    || ! printf "# %s\nexport %s='%s'\n" "$env_name" "$env_name" "$sh_value" > "$sh_secret"; then
+    umask "$old_umask"
+    msgr err "Failed to write secret files"
+    return 1
+  fi
+
+  # umask only governs newly created paths; re-tighten explicitly so a
+  # pre-existing dir/file with broader perms (e.g. 0755/0644) is fixed.
+  if ! chmod 700 "$(dirname "$fish_secret")" "$(dirname "$sh_secret")" \
+    || ! chmod 600 "$fish_secret" "$sh_secret"; then
+    umask "$old_umask"
+    msgr err "Failed to set secret file permissions"
+    return 1
+  fi
   umask "$old_umask"
 
   msgr yay "$env_name secrets created"

--- a/local/bin/dfm
+++ b/local/bin/dfm
@@ -85,6 +85,7 @@
 #USAGE   cmd "params" help="List all parameters"
 #USAGE }
 #USAGE cmd "secrets" help="Create shell secrets files" {
+#USAGE   cmd "create" help="Create secrets for an env var: create <ENV_NAME> [filename]"
 #USAGE   cmd "github" help="Create GITHUB_TOKEN secrets for all shells"
 #USAGE }
 #USAGE cmd "cleanup" help="Remove old installs, caches, and unused packages" {
@@ -874,46 +875,116 @@ section_tests()
   esac
 }
 
+# Derive a secrets filename from an env var name.
+# Lowercases the name, then strips a trailing credential-type suffix.
+# GITHUB_TOKEN -> github, SONAR_TOKEN -> sonar, FOO_API_KEY -> foo.
+# Callers can override the result by passing an explicit filename to
+# secrets_create (e.g. SONAR_TOKEN is stored as sonarcloud).
+secrets_filename_from_env()
+{
+  local name
+  name=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$name" in
+    *_api_key) name=${name%_api_key} ;;
+    *_token) name=${name%_token} ;;
+    *_secret) name=${name%_secret} ;;
+    *_password) name=${name%_password} ;;
+    *_key) name=${name%_key} ;;
+    *_pat) name=${name%_pat} ;;
+  esac
+  printf '%s' "$name"
+}
+
+# Create fish + bash/zsh secrets files for an environment variable.
+# Usage: secrets_create <ENV_NAME> [filename]
+# The value is read from a hidden prompt so it never reaches the
+# terminal, shell history, or the process table. Files are written with
+# a 077 umask so only the owner can read them.
+secrets_create()
+{
+  local env_name="$1"
+  local filename="$2"
+
+  if [[ -z "$env_name" ]]; then
+    msgr err "Usage: $SCRIPT secrets create <ENV_NAME> [filename]"
+    return 1
+  fi
+
+  # Reject anything that is not a valid POSIX shell identifier; otherwise
+  # the generated set/export lines would be syntactically broken.
+  if [[ ! "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    msgr err "Invalid environment variable name: $env_name"
+    msgr nested "Expected a shell identifier, e.g. GITHUB_TOKEN"
+    return 1
+  fi
+
+  [[ -z "$filename" ]] && filename=$(secrets_filename_from_env "$env_name")
+
+  # Guard against empty or path-traversing filenames so the secret can
+  # only ever land inside the two secrets.d directories.
+  if [[ ! "$filename" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    msgr err "Invalid secrets filename: $filename"
+    msgr nested "Allowed characters: letters, digits, '.', '_', '-'"
+    return 1
+  fi
+
+  local fish_secret="$DOTFILES/config/fish/secrets.d/$filename.fish"
+  local sh_secret="$DOTFILES/config/secrets.d/$filename.sh"
+
+  if [[ -f "$fish_secret" ]] || [[ -f "$sh_secret" ]]; then
+    msgr warn "Secrets files already exist — they will be overwritten"
+  fi
+
+  local secret
+  read -rsp "Enter $env_name (input hidden): " secret
+  echo
+
+  if [[ -z "$secret" ]]; then
+    msgr err "No value provided"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$fish_secret")" "$(dirname "$sh_secret")"
+
+  # Store the value single-quoted so secrets containing $, ", \, or
+  # backticks are written verbatim instead of being expanded or
+  # breaking the file. Each shell has different single-quote rules:
+  #   POSIX sh — fully literal; only ' must be escaped as '\''.
+  #   fish     — literal except \ and ', each escaped with a backslash.
+  local sh_value fish_value
+  sh_value=${secret//\'/\'\\\'\'}
+  fish_value=${secret//\\/\\\\}
+  fish_value=${fish_value//\'/\\\'}
+
+  local old_umask
+  old_umask=$(umask)
+  umask 077
+  printf "# %s\nset -x %s '%s'\n" "$env_name" "$env_name" "$fish_value" > "$fish_secret"
+  printf "# %s\nexport %s='%s'\n" "$env_name" "$env_name" "$sh_value" > "$sh_secret"
+  umask "$old_umask"
+
+  msgr yay "$env_name secrets created"
+  msgr nested "fish:     $fish_secret"
+  msgr nested "bash/zsh: $sh_secret"
+}
+
 # Handle secrets creation commands
 section_secrets()
 {
   USAGE_PREFIX="$SCRIPT secrets <command>"
 
   MENU=(
+    "create:Create secrets for an env var: create <ENV_NAME> [filename]"
     "github:Create GITHUB_TOKEN secrets for all shells"
   )
 
   case "$1" in
-    github)
-      local fish_secret="$DOTFILES/config/fish/secrets.d/github.fish"
-      local sh_secret="$DOTFILES/config/secrets.d/github.sh"
-
-      if [[ -f "$fish_secret" ]] || [[ -f "$sh_secret" ]]; then
-        msgr warn "Secrets files already exist — they will be overwritten"
-      fi
-
-      local token
-      read -rsp "Enter GITHUB_TOKEN (input hidden): " token
-      echo
-
-      if [[ -z "$token" ]]; then
-        msgr err "No token provided"
-        return 1
-      fi
-
-      mkdir -p "$(dirname "$fish_secret")" "$(dirname "$sh_secret")"
-
-      local old_umask
-      old_umask=$(umask)
-      umask 077
-      printf '# GitHub Personal Access Token\nset -x GITHUB_TOKEN "%s"\n' "$token" > "$fish_secret"
-      printf '# GitHub Personal Access Token\nexport GITHUB_TOKEN="%s"\n' "$token" > "$sh_secret"
-      umask "$old_umask"
-
-      msgr yay "GITHUB_TOKEN secrets created"
-      msgr nested "fish:     $fish_secret"
-      msgr nested "bash/zsh: $sh_secret"
+    create)
+      shift
+      secrets_create "$@"
       ;;
+
+    github) secrets_create GITHUB_TOKEN github ;;
 
     *) menu_builder "$USAGE_PREFIX" "${MENU[@]}" ;;
   esac

--- a/tests/dfm.bats
+++ b/tests/dfm.bats
@@ -349,3 +349,54 @@ fake_dotfiles()
   [ "$status" -eq 1 ]
   [[ "$output" == *"Invalid secrets name"* ]]
 }
+
+@test "dfm secrets create derives the filename by stripping the suffix" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'tok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create SONAR_TOKEN
+  [ -f "$tmp/config/fish/secrets.d/sonar.fish" ]
+  [ -f "$tmp/config/secrets.d/sonar.sh" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets create rejects a dot-only filename" {
+  run bash -c "printf 'tok\n' | bash local/bin/dfm secrets create FOO ."
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid secrets filename"* ]]
+}
+
+@test "dfm secrets create errors when the env name derives to nothing" {
+  run bash -c "printf 'tok\n' | bash local/bin/dfm secrets create _TOKEN"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not derive a filename"* ]]
+}
+
+@test "dfm secrets show rejects a path-traversing name" {
+  run bash local/bin/dfm secrets show ../evil
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid secrets name"* ]]
+}
+
+@test "dfm secrets create writes secrets.d directories owner-only" {
+  local tmp perms
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'tok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  perms="$(stat -f '%Lp' "$tmp/config/secrets.d" 2> /dev/null \
+    || stat -c '%a' "$tmp/config/secrets.d")"
+  [ "$perms" = "700" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets remove deletes a secret present in only one shell" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'tok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  rm -f "$tmp/config/fish/secrets.d/github.fish"
+  run bash -c "printf 'y\n' | DOTFILES='$tmp' bash local/bin/dfm secrets remove github"
+  [ "$status" -eq 0 ]
+  [ ! -f "$tmp/config/secrets.d/github.sh" ]
+  rm -rf "$tmp"
+}

--- a/tests/dfm.bats
+++ b/tests/dfm.bats
@@ -138,3 +138,126 @@ setup()
   run bash local/bin/dfm check host fakehostname
   [ "$status" -eq 1 ]
 }
+
+# ── Group 5: Secrets ──────────────────────────────────────────
+
+# Build a minimal fake DOTFILES tree so `dfm secrets create` writes
+# into a throwaway dir instead of the real repo. Only shared.sh and
+# msgr are needed for dfm to start.
+fake_dotfiles()
+{
+  local dir="$1"
+  mkdir -p "$dir/local/bin" "$dir/config"
+  cp local/bin/msgr "$dir/local/bin/"
+  : > "$dir/config/shared.sh"
+}
+
+@test "dfm secrets menu lists create and github" {
+  run bash local/bin/dfm secrets
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"create"* ]]
+  [[ "$output" == *"github"* ]]
+}
+
+@test "dfm secrets create with no env name errors" {
+  run bash local/bin/dfm secrets create
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "dfm secrets create rejects invalid env var name" {
+  run bash local/bin/dfm secrets create 1BAD
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid environment variable name"* ]]
+}
+
+@test "dfm secrets create rejects path-traversing filename" {
+  run bash local/bin/dfm secrets create GITHUB_TOKEN ../evil
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid secrets filename"* ]]
+}
+
+@test "dfm secrets create derives filename from env name and writes both shells" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  run bash -c "printf 'secretvalue\n' | DOTFILES='$tmp' bash local/bin/dfm secrets create GITHUB_TOKEN"
+  [ "$status" -eq 0 ]
+  [ -f "$tmp/config/fish/secrets.d/github.fish" ]
+  [ -f "$tmp/config/secrets.d/github.sh" ]
+  [[ "$(cat "$tmp/config/fish/secrets.d/github.fish")" == *"set -x GITHUB_TOKEN 'secretvalue'"* ]]
+  [[ "$(cat "$tmp/config/secrets.d/github.sh")" == *"export GITHUB_TOKEN='secretvalue'"* ]]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets create stores special characters verbatim in both shells" {
+  local tmp value
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  # A value with $, ", \, ', backtick and a space — chars that would be
+  # expanded or break the file if written inside double quotes. Pass it
+  # via stdin and positional args so the test harness never re-quotes it.
+  value=$'a$b"c\\d\'e f`g'
+  printf '%s\n' "$value" > "$tmp/in"
+
+  run bash -c 'DOTFILES="$1" bash local/bin/dfm secrets create MY_SECRET < "$2"' _ "$tmp" "$tmp/in"
+  [ "$status" -eq 0 ]
+
+  # sh: sourcing must yield the original value unchanged.
+  run bash -c '. "$1"; printf "%s" "$MY_SECRET"' _ "$tmp/config/secrets.d/my.sh"
+  [ "$output" = "$value" ]
+
+  # fish: sourcing must yield the original value unchanged.
+  if command -v fish > /dev/null 2>&1; then
+    run fish -c 'source $argv[1]; printf "%s" $MY_SECRET' "$tmp/config/fish/secrets.d/my.fish"
+    [ "$output" = "$value" ]
+  fi
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets create writes files readable only by owner" {
+  local tmp perms
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  run bash -c "printf 'tok\n' | DOTFILES='$tmp' bash local/bin/dfm secrets create GITHUB_TOKEN"
+  [ "$status" -eq 0 ]
+  perms="$(stat -f '%Lp' "$tmp/config/secrets.d/github.sh" 2> /dev/null \
+    || stat -c '%a' "$tmp/config/secrets.d/github.sh")"
+  [ "$perms" = "600" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets create honors an explicit filename" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  run bash -c "printf 'tok\n' | DOTFILES='$tmp' bash local/bin/dfm secrets create SONAR_TOKEN sonarcloud"
+  [ "$status" -eq 0 ]
+  [ -f "$tmp/config/fish/secrets.d/sonarcloud.fish" ]
+  [ -f "$tmp/config/secrets.d/sonarcloud.sh" ]
+  [[ "$(cat "$tmp/config/fish/secrets.d/sonarcloud.fish")" == *'set -x SONAR_TOKEN'* ]]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets create with empty value errors" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  run bash -c "printf '\n' | DOTFILES='$tmp' bash local/bin/dfm secrets create GITHUB_TOKEN"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No value provided"* ]]
+  [ ! -f "$tmp/config/secrets.d/github.sh" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets github delegates to create with github filename" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  run bash -c "printf 'ghtok\n' | DOTFILES='$tmp' bash local/bin/dfm secrets github"
+  [ "$status" -eq 0 ]
+  [ -f "$tmp/config/fish/secrets.d/github.fish" ]
+  [ -f "$tmp/config/secrets.d/github.sh" ]
+  [[ "$(cat "$tmp/config/secrets.d/github.sh")" == *"export GITHUB_TOKEN='ghtok'"* ]]
+  rm -rf "$tmp"
+}

--- a/tests/dfm.bats
+++ b/tests/dfm.bats
@@ -152,10 +152,13 @@ fake_dotfiles()
   : > "$dir/config/shared.sh"
 }
 
-@test "dfm secrets menu lists create and github" {
+@test "dfm secrets menu lists all subcommands" {
   run bash local/bin/dfm secrets
   [ "$status" -eq 0 ]
   [[ "$output" == *"create"* ]]
+  [[ "$output" == *"list"* ]]
+  [[ "$output" == *"show"* ]]
+  [[ "$output" == *"remove"* ]]
   [[ "$output" == *"github"* ]]
 }
 
@@ -260,4 +263,89 @@ fake_dotfiles()
   [ -f "$tmp/config/secrets.d/github.sh" ]
   [[ "$(cat "$tmp/config/secrets.d/github.sh")" == *"export GITHUB_TOKEN='ghtok'"* ]]
   rm -rf "$tmp"
+}
+
+@test "dfm secrets list reports nothing when no secrets exist" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  run bash -c "DOTFILES='$tmp' bash local/bin/dfm secrets list"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No secrets configured"* ]]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets list shows configured names and env vars without values" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'topsecret\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  run bash -c "DOTFILES='$tmp' bash local/bin/dfm secrets list"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"github"* ]]
+  [[ "$output" == *"GITHUB_TOKEN"* ]]
+  # The value must never appear in the listing.
+  [[ "$output" != *"topsecret"* ]]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets show displays the stored value" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'mytok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  run bash -c "DOTFILES='$tmp' bash local/bin/dfm secrets show github"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GITHUB_TOKEN"* ]]
+  [[ "$output" == *"mytok"* ]]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets show errors for an unknown secret" {
+  run bash local/bin/dfm secrets show nope
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No secret named"* ]]
+}
+
+@test "dfm secrets show with no name errors" {
+  run bash local/bin/dfm secrets show
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "dfm secrets remove deletes both files after confirmation" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'tok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  run bash -c "printf 'y\n' | DOTFILES='$tmp' bash local/bin/dfm secrets remove github"
+  [ "$status" -eq 0 ]
+  [ ! -f "$tmp/config/fish/secrets.d/github.fish" ]
+  [ ! -f "$tmp/config/secrets.d/github.sh" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets remove keeps files when not confirmed" {
+  local tmp
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  printf 'tok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  run bash -c "printf 'n\n' | DOTFILES='$tmp' bash local/bin/dfm secrets remove github"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Aborted"* ]]
+  [ -f "$tmp/config/fish/secrets.d/github.fish" ]
+  [ -f "$tmp/config/secrets.d/github.sh" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets remove errors for an unknown secret" {
+  run bash local/bin/dfm secrets remove nope
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No secret named"* ]]
+}
+
+@test "dfm secrets remove rejects a path-traversing name" {
+  run bash local/bin/dfm secrets remove ../evil
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid secrets name"* ]]
 }

--- a/tests/dfm.bats
+++ b/tests/dfm.bats
@@ -218,6 +218,20 @@ fake_dotfiles()
   rm -rf "$tmp"
 }
 
+@test "dfm secrets create preserves leading and trailing whitespace" {
+  local tmp value
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  # IFS= read must not trim surrounding spaces from the secret value.
+  value="  spaced value  "
+  printf '%s\n' "$value" > "$tmp/in"
+  run bash -c 'DOTFILES="$1" bash local/bin/dfm secrets create MY_SECRET < "$2"' _ "$tmp" "$tmp/in"
+  [ "$status" -eq 0 ]
+  run bash -c '. "$1"; printf "%s" "$MY_SECRET"' _ "$tmp/config/secrets.d/my.sh"
+  [ "$output" = "$value" ]
+  rm -rf "$tmp"
+}
+
 @test "dfm secrets create writes files readable only by owner" {
   local tmp perms
   tmp="$(mktemp -d)"
@@ -386,6 +400,26 @@ fake_dotfiles()
   perms="$(stat -f '%Lp' "$tmp/config/secrets.d" 2> /dev/null \
     || stat -c '%a' "$tmp/config/secrets.d")"
   [ "$perms" = "700" ]
+  rm -rf "$tmp"
+}
+
+@test "dfm secrets create re-tightens pre-existing broad permissions" {
+  local tmp fperms dperms
+  tmp="$(mktemp -d)"
+  fake_dotfiles "$tmp"
+  # Simulate a secret created the old way, world-readable.
+  mkdir -p "$tmp/config/fish/secrets.d" "$tmp/config/secrets.d"
+  printf 'old\n' > "$tmp/config/secrets.d/github.sh"
+  printf 'old\n' > "$tmp/config/fish/secrets.d/github.fish"
+  chmod 644 "$tmp/config/secrets.d/github.sh" "$tmp/config/fish/secrets.d/github.fish"
+  chmod 755 "$tmp/config/secrets.d"
+  printf 'newtok\n' | DOTFILES="$tmp" bash local/bin/dfm secrets create GITHUB_TOKEN
+  fperms="$(stat -f '%Lp' "$tmp/config/secrets.d/github.sh" 2> /dev/null \
+    || stat -c '%a' "$tmp/config/secrets.d/github.sh")"
+  dperms="$(stat -f '%Lp' "$tmp/config/secrets.d" 2> /dev/null \
+    || stat -c '%a' "$tmp/config/secrets.d")"
+  [ "$fperms" = "600" ]
+  [ "$dperms" = "700" ]
   rm -rf "$tmp"
 }
 

--- a/tests/x-backup-mysql-with-prefix.bats
+++ b/tests/x-backup-mysql-with-prefix.bats
@@ -3,6 +3,7 @@
 setup()
 {
   STUB_DIR="$(mktemp -d)"
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
   # mysql stub: returns two table names after the header
   cat > "$STUB_DIR/mysql" << 'STUB'
@@ -22,7 +23,12 @@ STUB
   chmod +x "$STUB_DIR/mysqldump"
 
   export PATH="$STUB_DIR:$PATH"
-  export STUB_DIR
+  export STUB_DIR REPO_ROOT
+
+  # The script writes its <db>_<name>_<timestamp>.sql dump to the current
+  # directory. Run from inside STUB_DIR so that artifact lands there and is
+  # removed by teardown instead of polluting the repo root.
+  cd "$STUB_DIR" || return 1
 }
 
 teardown()
@@ -31,7 +37,7 @@ teardown()
 }
 
 @test "x-backup-mysql-with-prefix: passes each table as a separate argument" {
-  run bash local/bin/x-backup-mysql-with-prefix wp_ mysite wordpress
+  run bash "$REPO_ROOT/local/bin/x-backup-mysql-with-prefix" wp_ mysite wordpress
   [ "$status" -eq 0 ]
   local argc
   argc=$(cat "$STUB_DIR/argc.txt")
@@ -40,6 +46,6 @@ teardown()
 }
 
 @test "x-backup-mysql-with-prefix: exits 1 without required arguments" {
-  run bash local/bin/x-backup-mysql-with-prefix
+  run bash "$REPO_ROOT/local/bin/x-backup-mysql-with-prefix"
   [ "$status" -eq 1 ]
 }

--- a/tests/x-path.bats
+++ b/tests/x-path.bats
@@ -1,5 +1,19 @@
 #!/usr/bin/env bats
 
+# These tests deliberately shrink PATH to assert path-manipulation behavior.
+# On macOS rm lives in /bin, so a test leaving PATH="/usr/bin" breaks bats'
+# own post-test cleanup (rm). Save the real PATH and restore it in teardown,
+# which runs before that cleanup.
+setup()
+{
+  REAL_PATH="$PATH"
+}
+
+teardown()
+{
+  PATH="$REAL_PATH"
+}
+
 @test "x-path-append adds directory" {
   mkdir -p "$BATS_TMPDIR/dir"
   PATH="/usr/bin"

--- a/tests/x-quota-usage.bats
+++ b/tests/x-quota-usage.bats
@@ -47,6 +47,8 @@ STUB
   [ "$status" -eq 0 ]
   [[ "$output" == *"Mount"* ]]
   [[ "$output" == *"50.0%"* ]]
+  # The 25-char bar of '#'/'_' inside brackets must actually render.
+  [[ "$output" =~ \[[#_]{25}\] ]]
 }
 
 @test "x-quota-usage: exits 1 when quota output is empty" {

--- a/tests/x-quota-usage.bats
+++ b/tests/x-quota-usage.bats
@@ -24,16 +24,34 @@ teardown()
   rm -rf "$STUB_DIR"
 }
 
-@test "x-quota-usage: exits 0 with no PHP warnings when quota is zero" {
-  run php local/bin/x-quota-usage.php
+@test "x-quota-usage: skips zero-quota rows without dividing by zero" {
+  run local/bin/x-quota-usage
   [ "$status" -eq 0 ]
-  [[ "$output" != *"Division by zero"* ]]
-  [[ "$output" != *"Warning"* ]]
+  [[ "$output" != *"division by zero"* ]]
+  # The only row has quota 0, so it is filtered out and no table is rendered.
+  [[ "$output" != *"Mount"* ]]
 }
 
-@test "x-quota-usage: exits non-zero when quota binary is missing" {
-  local no_quota
-  no_quota="$(mktemp -d)"
-  run -127 env PATH="$no_quota" php local/bin/x-quota-usage.php
-  rm -rf "$no_quota"
+@test "x-quota-usage: renders a usage bar for a non-zero quota" {
+  cat > "$STUB_DIR/quota" << 'STUB'
+#!/usr/bin/env sh
+printf '%s\n' "Filesystem  kbytes   quota    limit"
+printf '%s\n' "---"
+printf '%s\n' "/dev/disk1  500000   1000000  1200000"
+STUB
+  chmod +x "$STUB_DIR/quota"
+
+  run local/bin/x-quota-usage
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Mount"* ]]
+  [[ "$output" == *"50.0%"* ]]
+}
+
+@test "x-quota-usage: exits 1 when quota output is empty" {
+  printf '#!/usr/bin/env sh\n' > "$STUB_DIR/quota"
+  chmod +x "$STUB_DIR/quota"
+
+  run local/bin/x-quota-usage
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"quota was empty"* ]]
 }

--- a/tests/x-quota-usage.bats
+++ b/tests/x-quota-usage.bats
@@ -41,7 +41,9 @@ printf '%s\n' "/dev/disk1  500000   1000000  1200000"
 STUB
   chmod +x "$STUB_DIR/quota"
 
-  run local/bin/x-quota-usage
+  # Force LC_ALL=C so the awk "%.1f" percentage uses a '.' decimal
+  # separator regardless of the host locale (e.g. fi_FI prints "50,0").
+  run env LC_ALL=C local/bin/x-quota-usage
   [ "$status" -eq 0 ]
   [[ "$output" == *"Mount"* ]]
   [[ "$output" == *"50.0%"* ]]


### PR DESCRIPTION
## Summary

Adds a full `dfm secrets` management surface and fixes several stale/leaky tests found along the way.

### `dfm secrets` subcommands

- **`create <ENV_NAME> [filename]`** — prompts for the value with hidden input (no shell history / process-table exposure) and writes the fish + bash/zsh files. Filename is derived from the env name when omitted (`GITHUB_TOKEN` → `github`); pass one explicitly when the convention differs (`SONAR_TOKEN sonarcloud`). Values are single-quoted with per-shell escaping, so secrets containing `$ " \` or backticks are stored verbatim instead of being expanded or breaking the file.
- **`list`** — one row per secret: name, env var(s), and which shells have a file. **Never prints values.**
- **`show <name>`** — prints a secret's file contents (intentionally reveals the value — you inspecting your own secret).
- **`remove <name>`** — deletes the fish + bash/zsh files after a `[y/N]` confirmation.
- **`github`** — refactored to delegate to `create GITHUB_TOKEN github` (identical output, no duplication).

Files are written under a `077` umask: directories `0700`, files `0600` (owner-only). Names are validated to start alphanumeric and contain only `[A-Za-z0-9._-]`, blocking path traversal and hidden-dotfile names. Tab completions (fish/bash/zsh) are generated from the `#USAGE` spec, which now covers every subcommand and its args.

### Test / hygiene fixes (unblocks `./test-all.sh`)

- **`x-quota-usage`** test rewritten to invoke the current POSIX `sh` script (it had been rewritten from PHP; the old test called the removed `x-quota-usage.php` and errored). Render assertion forced to `LC_ALL=C` so it holds under comma-decimal locales (e.g. `fi_FI`).
- **`x-backup-mysql-with-prefix`** test now runs in an isolated temp dir so its generated `*.sql` dump no longer lands in the repo root.
- **`x-path`** test saves/restores `PATH` so bats' own post-test cleanup keeps finding `rm` (macOS `rm` lives in `/bin`, not `/usr/bin`) — removes the `rm: command not found` noise in `./test-all.sh`.
- **`.gitignore`** ignores `*.sql`.

## Testing

- `dfm.bats`: 41 tests covering create (derivation, validation, traversal, special chars, perms, empty value, delegation), list (empty/populated, value-never-leaks), show (value/unknown/no-arg/traversal), remove (confirm/abort/unknown/traversal/single-shell), and directory perms.
- Full suite: 134/134 pass, including under `LC_ALL=fi_FI.UTF-8`.
- `shellcheck`, `shfmt`, `yarn lint`, and `usage lint` all clean.

The branch was hardened via an adversarial review pass (see commit `be78408`).

## Notes

- The fish/bash/zsh completion files are gitignored generated artifacts (regenerated by `dfm install` / `scripts/install-completions.sh`), so they are not part of this diff.
