### PR TITLE
feat(x): add git-style x-* dispatcher with tab-completion

### DIFF
--- a/config/fish/completions/x.fish
+++ b/config/fish/completions/x.fish
@@ -1,0 +1,45 @@
+# Completions for x — dynamically discovers x-* sibling commands.
+# Not auto-generated. install-completions.sh is patched to skip x
+# because subcommands are discovered at runtime, not statically declared.
+
+function __x_list_commands
+    set -l x_path (command -v x 2>/dev/null)
+    test -n "$x_path" || return
+
+    # Resolve symlinks (BSD-portable, no readlink -f) so completions and the
+    # dispatcher agree on which directory contains x-* siblings.
+    while test -L "$x_path"
+        set -l link (readlink "$x_path")
+        if string match -q '/*' -- "$link"
+            set x_path "$link"
+        else
+            set x_path (dirname "$x_path")/"$link"
+        end
+    end
+    set -l x_dir (dirname "$x_path")
+
+    for f in "$x_dir"/x-*
+        test -x "$f" || continue
+        set -l name (string replace -r '.*/x-' '' -- "$f")
+        # Skip files with extensions (e.g. x-foo.py, x-foo.pl)
+        if string match -qr '\.' -- "$name"
+            continue
+        end
+        # Prefer #USAGE about, fall back to # @description
+        set -l desc (grep -m1 '#USAGE about' "$f" 2>/dev/null \
+            | string replace -r '#USAGE about "(.+)"' '$1')
+        if test -z "$desc"
+            set desc (grep -m1 '# @description' "$f" 2>/dev/null \
+                | string replace -r '# @description ' '')
+        end
+        printf '%s\t%s\n' "$name" "$desc"
+    end
+end
+
+# Disable default file completions for x
+complete -c x -f
+
+# Complete the subcommand name when no subcommand has been given yet
+complete -c x -f \
+    -n 'not __fish_seen_subcommand_from (__x_list_commands | string replace -r "\t.*" "")' \
+    -a '(__x_list_commands)'

--- a/local/bin/x
+++ b/local/bin/x
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# @description Git-style dispatcher for x-* utility scripts
+#USAGE about "Git-style dispatcher for x-* utility scripts"
+#USAGE arg "[command]" help="x-* subcommand to run (omit to list all)"
+#USAGE arg "[args...]" help="Arguments passed to the subcommand"
+#
+# `x <command> [args...]` resolves and execs `x-<command>` (sibling of
+# this script first, then $PATH), mirroring how git finds git-<command>.
+#
+# (c) Ismo Vuorinen <https://github.com/ivuorinen> 2026
+# Licensed under MIT, see LICENSE
+#
+# vim: ft=bash ts=2 sw=2 et
+# shellcheck source-path=$HOME/.dotfiles/local/bin
+
+# Resolve real directory through symlinks (macOS/BSD-portable, no readlink -f).
+# When `x` is invoked via a ~/.local/bin/x symlink a plain dirname "$0" would
+# yield ~/.local/bin, missing any newly added x-* siblings in the repo's
+# local/bin. Following the symlink chain makes `x <new-sub>` work the moment
+# the file is dropped in — no re-link needed.
+_x_src="$0"
+while [ -h "$_x_src" ]; do
+  _x_link_dir=$(
+    unset CDPATH
+    cd -P -- "$(dirname -- "$_x_src")" && pwd
+  )
+  _x_src=$(readlink "$_x_src")
+  case "$_x_src" in
+    /*) ;;
+    *) _x_src="$_x_link_dir/$_x_src" ;;
+  esac
+done
+_x_selfdir=$(
+  unset CDPATH
+  cd -P -- "$(dirname -- "$_x_src")" && pwd
+)
+
+# shellcheck source=local/bin/msgr
+. "$_x_selfdir/msgr"
+
+SCRIPT="${0##*/}"
+
+# Extract the first description line from a script file.
+# Prefers #USAGE about over # @description for consistency.
+_x_desc()
+{
+  local f="$1" line desc
+  while IFS= read -r line; do
+    case "$line" in
+      '#USAGE about "'*)
+        desc="${line#'#USAGE about "'}"
+        printf '%s' "${desc%'"'}"
+        return
+        ;;
+      '# @description '*)
+        printf '%s' "${line#'# @description '}"
+        return
+        ;;
+    esac
+  done < "$f"
+}
+
+usage()
+{
+  echo ""
+  msgr prompt "Usage: $SCRIPT <command> [args...]"
+  echo ""
+  echo "  Available x-* commands:"
+  echo ""
+
+  local f name desc maxlen=0
+  local -a entries=()
+
+  for f in "$_x_selfdir"/x-*; do
+    [ -x "$f" ] || continue
+    name="${f##*/x-}"
+    # Skip files with extensions (e.g. x-foo.py, x-foo.pl, x-foo.md)
+    case "$name" in *.*) continue ;; esac
+    [ ${#name} -gt "$maxlen" ] && maxlen=${#name}
+    desc=$(_x_desc "$f")
+    entries+=("$name|$desc")
+  done
+
+  if [ ${#entries[@]} -eq 0 ]; then
+    echo "  (no x-* commands found in $_x_selfdir)"
+    echo ""
+    return
+  fi
+
+  local entry
+  local -a sorted_entries
+  mapfile -t sorted_entries < <(printf '%s\n' "${entries[@]}" | sort)
+
+  for entry in "${sorted_entries[@]}"; do
+    printf '    %-*s  %s\n' "$maxlen" "${entry%%|*}" "${entry#*|}"
+  done
+  echo ""
+}
+
+main()
+{
+  local sub="${1:-}"
+  [ $# -gt 0 ] && shift
+
+  case "$sub" in
+    "" | help | -h | --help)
+      usage
+      return 0
+      ;;
+  esac
+
+  # Sibling-first lookup, then $PATH (git-style). The -x guard ensures we
+  # never try to exec a non-executable file (e.g. an .md sidecar).
+  local cand="$_x_selfdir/x-$sub"
+  if [ -x "$cand" ]; then
+    exec "$cand" "$@"
+  fi
+
+  local resolved
+  resolved=$(command -v "x-$sub" 2> /dev/null)
+  if [ -n "$resolved" ] && [ -x "$resolved" ]; then
+    exec "$resolved" "$@"
+  fi
+
+  msgr err "$SCRIPT: unknown command '$sub'"
+  usage
+  return 1
+}
+
+main "$@"

--- a/scripts/install-completions.sh
+++ b/scripts/install-completions.sh
@@ -84,6 +84,32 @@ generate_for_spec()
   ((count++)) || true
 }
 
+generate_docs_only()
+{
+  local spec="$1"
+  local bin_name="$2"
+
+  logger::info "Generating docs for: $bin_name"
+
+  if usage generate markdown -f "$spec" --out-file "$MD_DIR/$bin_name.md" 2>&1; then
+    :
+  else
+    logger::warn "markdown generation failed for $bin_name"
+    rm -f "$MD_DIR/$bin_name.md"
+    ((errors++)) || true
+  fi
+
+  if usage generate manpage -f "$spec" --out-file "$MAN_DIR/$bin_name.1" 2>&1; then
+    :
+  else
+    logger::warn "manpage generation failed for $bin_name"
+    rm -f "$MAN_DIR/$bin_name.1"
+    ((errors++)) || true
+  fi
+
+  ((count++)) || true
+}
+
 # Process local/bin inline specs (#USAGE or //USAGE directives embedded in script)
 for spec in "$DOTFILES"/local/bin/*; do
   [[ -f "$spec" ]] || continue
@@ -96,6 +122,7 @@ for spec in "$DOTFILES"/local/bin/*; do
   # rather than generated individually.
   case "$bin_name" in
     dfm | dfm-*) continue ;;
+    x) continue ;; # hand-crafted completion; docs generated below
     *) ;;
   esac
   generate_for_spec "$spec" "$bin_name"
@@ -126,6 +153,12 @@ if [[ -f "$DOTFILES/local/bin/dfm" ]]; then
   } > "$dfm_spec"
   generate_for_spec "$dfm_spec" "dfm"
   rm -rf "$dfm_spec_dir"
+fi
+
+# x: generate docs + manpage only — fish completion is hand-crafted in
+# config/fish/completions/x.fish because subcommands are discovered dynamically.
+if [[ -f "$DOTFILES/local/bin/x" ]]; then
+  generate_docs_only "$DOTFILES/local/bin/x" "x"
 fi
 
 # Process scripts/ inline .sh specs (#USAGE directives embedded in script)


### PR DESCRIPTION
## Summary

- Adds `local/bin/x` — thin git-style dispatcher that resolves and execs `x-<command>` (sibling-first, then \$PATH), mirroring how `dfm` works. Running `x` with no args lists all discovered `x-*` scripts alphabetically with descriptions.
- Adds `config/fish/completions/x.fish` — hand-crafted dynamic Fish completion. `x <tab>` scans for `x-*` siblings at completion time and presents names and descriptions. Force-added despite the `config/fish/completions/*.fish` gitignore (same pattern as `docker.fish`, `git-profile.fish`, etc.).
- Updates `scripts/install-completions.sh` — adds `generate_docs_only()`, excludes `x` from the auto-generation loop (which would overwrite the hand-crafted completion), and adds a docs-only step so markdown docs and manpages are still generated from `x`'s inline `#USAGE` spec.

## Test plan

- [ ] `x` — lists all `x-*` commands with descriptions, alphabetically sorted
- [ ] `x <command>` — dispatches to the corresponding `x-<command>` script
- [ ] `x <tab>` in Fish — shows subcommand names with descriptions, no files mixed in
- [ ] `x <unknown>` — prints error and usage, exits 1
- [ ] `scripts/install-completions.sh` — completes without errors; does not overwrite `x.fish`