### PR TITLE
refactor(nvim): mini.nvim completion, pack-ui TUI, and config cleanup

### DIFF
--- a/config/nvim/CLAUDE.md
+++ b/config/nvim/CLAUDE.md
@@ -28,15 +28,15 @@ All configuration runs in `init.lua` at step 7b of `:h initialization`:
 
 | Section         | Content                                                         |
 |-----------------|-----------------------------------------------------------------|
-| `-- Completion` | blink.cmp (lsp / path / snippets / buffer / omni)               |
+| `-- Completion` | mini.completion (LSP-aware, from mini.nvim)                     |
 | `-- Editor`     | mini.nvim suite + vim-sleuth                                    |
 | `-- LSP`        | mason stack + `vim.lsp.config` / `vim.lsp.enable`               |
 | `-- Navigation` | trouble.nvim                                                    |
 | `-- QA`         | conform.nvim (format-on-save) + nvim-lint                       |
 | `-- Snacks`     | snacks.nvim: picker, notifier, terminal, input, rename, bigfile |
-| `-- Tools`      | wakatime, shellspec, comment-box                                |
+| `-- Tools`      | wakatime, shellspec, mini.comment                               |
 | `-- Treesitter` | arborist.nvim (parser manager, Neovim 0.12+)                    |
-| `-- UI`         | catppuccin, auto-dark-mode, colorizer, render-markdown          |
+| `-- UI`         | catppuccin, auto-dark-mode, colorizer                           |
 
 Special-buffer pinning (formerly `stickybuf.nvim`) lives in
 `lua/autogroups.lua` as a `winfixbuf` autocmd. The file explorer is
@@ -97,7 +97,6 @@ from TOOL_CONFIGS: `shfmt`, `fish_indent`, `gofmt`, `goimports`,
 |--------------|------------------------|
 | `<leader>b`  | Buffers                |
 | `<leader>c`  | Code                   |
-| `<leader>cb` | CommentBox             |
 | `<leader>cc` | Calls                  |
 | `<leader>q`  | Quit                   |
 | `<leader>s`  | Search (snacks.picker) |
@@ -114,7 +113,7 @@ Source of truth: the `clues` table in the `-- Editor` section of `init.lua`.
 mason (installs binaries via `mason-tool-installer`) +
 `mason-lspconfig` (auto-enables all mason-installed servers via `vim.lsp.enable`) +
 native `lsp/*.lua` files (customizations only) +
-`vim.lsp.config('*', ...)` in the `-- LSP` section of `init.lua`, with capabilities from blink.cmp.
+`vim.lsp.config('*', ...)` in the `-- LSP` section of `init.lua`.
 
 **How it works:** The `-- LSP` section of `init.lua` calls `require('lspconfig')` to populate
 `vim.lsp.config` with nvim-lspconfig's defaults for all servers. Any

--- a/config/nvim/README.md
+++ b/config/nvim/README.md
@@ -8,20 +8,22 @@ User commands (`PackUpdate`, `PackRemove`, `PackList`) live in `lua/pack.lua`.
 
 ## Completion
 
-**blink.cmp** — `https://github.com/saghen/blink.cmp`
+**mini.completion** — part of `https://github.com/nvim-mini/mini.nvim`
 
-Completion engine with sources: `lsp`, `path`, `snippets`, `buffer`, `omni`.
-Inline signature help enabled. Lua fuzzy matcher (`fuzzy.implementation = 'lua'`).
-`<C-x>` toggles the completion menu and documentation popup.
+LSP-aware completion via `completefunc`. `<C-Space>` triggers manually;
+completion fires automatically after a short delay. `<Tab>`/`<S-Tab>` navigate,
+`<CR>` confirms, `<C-e>` dismisses.
 
 ## Editor
 
 ### mini.nvim — `https://github.com/nvim-mini/mini.nvim`
 
-17 independent modules from a single plugin:
+19 independent modules from a single plugin:
 
 | Module           | Role                                                                  |
 |------------------|-----------------------------------------------------------------------|
+| mini.completion  | LSP-aware completion via `completefunc`; auto-trigger + `<C-Space>`   |
+| mini.comment     | `gc` toggle comment operator; `gcc` for current line                  |
 | mini.ai          | Textobjects: `va)`, `yinq`, `ci'`; 750-line lookahead                 |
 | mini.operators   | `g=` evaluate, `gx` exchange, `gm` duplicate, `gR` replace, `gs` sort |
 | mini.splitjoin   | Split/join arguments and lists (`gS`)                                 |
@@ -57,8 +59,8 @@ URLs: `github.com/neovim/nvim-lspconfig` · `github.com/williamboman/mason.nvim`
 `github.com/williamboman/mason-lspconfig.nvim` ·
 `github.com/WhoIsSethDaniel/mason-tool-installer.nvim`
 
-blink.cmp capabilities are registered on `vim.lsp.config('*', ...)` before
-mason-lspconfig enables servers. `fish_lsp` and `taplo` are mise-managed and
+`vim.lsp.protocol.make_client_capabilities()` is registered on `vim.lsp.config('*', ...)`
+before mason-lspconfig enables servers. `fish_lsp` and `taplo` are mise-managed and
 enabled explicitly via `vim.lsp.enable { 'fish_lsp', 'taplo' }`.
 
 ### LSP Servers
@@ -169,14 +171,13 @@ Multi-feature plugin; each snack is independently toggleable:
 
 ## Tools
 
-| Plugin           | Role                                                     |
-|------------------|----------------------------------------------------------|
-| vim-wakatime     | Automatic coding time tracking via WakaTime              |
-| nvim-shellspec   | ShellSpec filetype support (auto-format, 2-space indent) |
-| comment-box.nvim | Comment boxes and separators (`<leader>cb*` keymaps)     |
+| Plugin         | Role                                                     |
+|----------------|----------------------------------------------------------|
+| vim-wakatime   | Automatic coding time tracking via WakaTime              |
+| nvim-shellspec | ShellSpec filetype support (auto-format, 2-space indent) |
+| mini.comment   | Toggle comments via `gc`/`gcc` (from mini.nvim)          |
 
-URLs: `github.com/wakatime/vim-wakatime` · `github.com/ivuorinen/nvim-shellspec` ·
-`github.com/LudoPinelli/comment-box.nvim`
+URLs: `github.com/wakatime/vim-wakatime` · `github.com/ivuorinen/nvim-shellspec`
 
 ## Treesitter
 
@@ -191,16 +192,14 @@ Core parsers always installed: `html`, `lua`, `luadoc`, `markdown`,
 
 ## UI
 
-| Plugin               | Role                                                                 |
-|----------------------|----------------------------------------------------------------------|
-| catppuccin/nvim      | Colorscheme; `auto_integrations` picks up mini.nvim; dim_inactive on |
-| auto-dark-mode.nvim  | Polls OS every 1 s; syncs `background` with system dark/light state  |
-| nvim-colorizer.lua   | Highlights hex color codes in-buffer; named colors disabled          |
-| render-markdown.nvim | Renders markdown headings, tables, code blocks inline; LaTeX off     |
+| Plugin              | Role                                                                 |
+|---------------------|----------------------------------------------------------------------|
+| catppuccin/nvim     | Colorscheme; `auto_integrations` picks up mini.nvim; dim_inactive on |
+| auto-dark-mode.nvim | Polls OS every 1 s; syncs `background` with system dark/light state  |
+| nvim-colorizer.lua  | Highlights hex color codes in-buffer; named colors disabled          |
 
 URLs: `github.com/catppuccin/nvim` · `github.com/f-person/auto-dark-mode.nvim` ·
-`github.com/catgoose/nvim-colorizer.lua` ·
-`github.com/MeanderingProgrammer/render-markdown.nvim`
+`github.com/catgoose/nvim-colorizer.lua`
 
 ## Installed Tools (mason-tool-installer)
 

--- a/config/nvim/ftdetect/ansible.lua
+++ b/config/nvim/ftdetect/ansible.lua
@@ -1,3 +1,5 @@
+-- Detect yaml.ansible filetype by directory path conventions.
+-- ansible-language-server uses this compound type to activate.
 vim.filetype.add {
   pattern = {
     ['.*/playbooks?/.*%.ya?ml'] = 'yaml.ansible',

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -25,6 +25,7 @@ require 'utils' -- registers K + HasConfig/Gated/TOOL_CONFIGS globals
 
 require 'keymaps'
 require 'pack'
+require 'pack-ui'
 
 -- ── Plugins ─────────────────────────────────────────────────────────
 -- version = vim.version.range '*' is set only on plugins that publish
@@ -65,6 +66,7 @@ require('mini.completion').setup()
 --  - va)  - [V]isually select [A]round [)]paren
 --  - yinq - [Y]ank [I]nside [N]ext [Q]uote
 --  - ci'  - [C]hange [I]nside [']quote
+-- n_lines=750: look further for text-objects in long functions (default 50)
 require('mini.ai').setup { n_lines = 750 }
 
 -- Text edit operators
@@ -173,11 +175,13 @@ miniclue.setup {
 require('mini.diff').setup()
 
 -- Session management (auto per-directory)
+---@module 'mini.sessions'
 local sessions = require 'mini.sessions'
 sessions.setup {
-  autowrite = false,
+  autowrite = false, -- VimLeavePre in autogroups.lua writes manually; avoid double-write
+  -- falls back to stdpath('data')/sessions when vim.g.sessions_dir is not set
   directory = vim.g.sessions_dir or vim.fn.stdpath 'data' .. '/sessions',
-  file = '',
+  file = '', -- '' disables per-directory Session.vim; only directory-based sessions used
 }
 
 -- ── Appearance ───────────────────────────────────────────────────────
@@ -189,6 +193,7 @@ require('mini.animate').setup()
 require('mini.cursorword').setup()
 
 -- Highlight patterns in text
+---@module 'mini.hipatterns'
 local hp = require 'mini.hipatterns'
 hp.setup {
   highlighters = {
@@ -237,6 +242,7 @@ require('mini.icons').setup {
 require('mini.icons').mock_nvim_web_devicons()
 
 -- Visualize and work with indent scope
+---@module 'mini.indentscope'
 local iscope = require 'mini.indentscope'
 iscope.setup {
   draw = { animation = iscope.gen_animation.none() },
@@ -246,8 +252,9 @@ iscope.setup {
 ---@module 'mini.statusline'
 local sl = require 'mini.statusline'
 sl.setup {
-  use_icons = true,
-  set_vim_settings = true,
+  -- set_vim_settings=false: prevent mini.statusline from overriding laststatus=3
+  -- (its default true hard-codes laststatus=2 and ruler=false, undoing options.lua)
+  set_vim_settings = false,
   content = {
     active = function()
       local mode, mode_hl = sl.section_mode { trunc_width = 100 }
@@ -313,6 +320,7 @@ map_combo('t', 'kj', '<BS><BS><C-\\><C-n>')
 -- The local lsp/*.lua files merge on top, so only customizations live there.
 require 'lspconfig'
 
+-- Mason manages LSP server binary downloads and installations
 require('mason').setup {}
 
 -- Set capabilities before mason-lspconfig enables servers so the config store
@@ -335,19 +343,14 @@ require('mason-tool-installer').setup {
   -- and enabled explicitly via vim.lsp.enable below.
   ensure_installed = {
     -- LSP servers (mason package names)
-    'ansible-language-server',
     'bash-language-server',
-    'css-lsp',
-    'dockerfile-language-server',
     'eslint-lsp',
     'gopls',
     'html-lsp',
-    'intelephense',
     'json-lsp',
     'lua-language-server',
     'pyright',
     'tailwindcss-language-server',
-    'terraform-ls',
     'typescript-language-server',
     'vim-language-server',
     'yaml-language-server',
@@ -373,15 +376,15 @@ vim.lsp.enable { 'fish_lsp', 'taplo' }
 
 -- https://github.com/folke/trouble.nvim
 require('trouble').setup {
-  auto_close = true,
+  auto_close = true, -- close the list when no items remain
   preview = { type = 'main', scratch = true },
   keys = {
-    j = 'next',
+    j = 'next', -- jump to next item (skips non-item lines unlike raw j)
     k = 'prev',
   },
   modes = {
     diagnostics = {
-      auto_open = false,
+      auto_open = false, -- don't open on :w; open explicitly with <leader>xx
     },
     test = {
       mode = 'diagnostics',
@@ -412,10 +415,12 @@ require('trouble').setup {
 
 -- ── Formatting ───────────────────────────────────────────────────────
 
+---@module 'conform'
 local conform = require 'conform'
 
-vim.g.autoformat_enabled = true
+vim.g.autoformat_enabled = true -- initial state; toggled by <leader>tf
 
+-- Exposed to mini.statusline content function for the fmt indicator
 function _G.autoformat_status() return vim.g.autoformat_enabled and 'fmt' or '' end
 
 conform.setup {
@@ -441,6 +446,7 @@ conform.setup {
     taplo = Gated 'taplo',
   },
   default_format_opts = {
+    -- 'fallback': use LSP formatting if no conform formatter handles the filetype
     lsp_format = 'fallback',
   },
   format_on_save = function(bufnr)
@@ -453,13 +459,14 @@ conform.setup {
 
     return { timeout_ms = 500 }
   end,
-  notify_on_error = true,
 }
 
+-- Delegate gq/gw range formatting to conform (falls back to LSP)
 vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"
 
 -- ── Linting ──────────────────────────────────────────────────────────
 
+---@module 'lint'
 local lint = require 'lint'
 
 lint.linters_by_ft = {
@@ -583,7 +590,7 @@ vim.cmd.colorscheme 'catppuccin'
 -- ── Auto dark mode ───────────────────────────────────────────────────
 -- https://github.com/f-person/auto-dark-mode.nvim
 require('auto-dark-mode').setup {
-  update_interval = 1000,
+  update_interval = 1000, -- poll every 1s (default 3000)
   -- stylua: ignore
   set_dark_mode = function()
     vim.api.nvim_set_option_value('background', 'dark', {})
@@ -599,7 +606,7 @@ require('auto-dark-mode').setup {
 -- https://github.com/catgoose/nvim-colorizer.lua
 require('colorizer').setup {
   user_default_options = {
-    names = false,
+    names = false, -- don't highlight CSS color names ('red', 'blue', etc.)
   },
 }
 

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -28,10 +28,9 @@ require 'pack'
 
 -- ── Plugins ─────────────────────────────────────────────────────────
 -- version = vim.version.range '*' is set only on plugins that publish
--- semver-tagged releases (blink.cmp, snacks.nvim). The remaining plugins
+-- semver-tagged releases (snacks.nvim). The remaining plugins
 -- have no tags vim.pack can constrain, so they track their default branch.
 vim.pack.add {
-  { src = 'https://github.com/saghen/blink.cmp', version = vim.version.range '*' },
   'https://github.com/nvim-mini/mini.nvim',
   'https://github.com/tpope/vim-sleuth',
   'https://github.com/neovim/nvim-lspconfig',
@@ -45,56 +44,16 @@ vim.pack.add {
   { src = 'https://github.com/folke/snacks.nvim', version = vim.version.range '*' },
   'https://github.com/wakatime/vim-wakatime',
   'https://github.com/ivuorinen/nvim-shellspec',
-  'https://github.com/LudoPinelli/comment-box.nvim',
   'https://github.com/arborist-ts/arborist.nvim',
   { src = 'https://github.com/catppuccin/nvim', name = 'catppuccin' },
   'https://github.com/f-person/auto-dark-mode.nvim',
   'https://github.com/catgoose/nvim-colorizer.lua',
-  'https://github.com/MeanderingProgrammer/render-markdown.nvim',
 }
 
 -- ── Completion ───────────────────────────────────────────────────────
--- Performant, batteries-included completion plugin for Neovim
--- https://github.com/saghen/blink.cmp
-
----@module 'blink.cmp'
-require('blink.cmp').setup {
-  keymap = {
-    ['<C-x>'] = { 'show', 'show_documentation', 'hide_documentation' },
-  },
-
-  appearance = {
-    use_nvim_cmp_as_default = true,
-  },
-
-  completion = {
-    menu = {
-      draw = {
-        columns = {
-          { 'label', 'label_description', gap = 1 },
-          { 'kind_icon', 'kind', gap = 1 },
-        },
-      },
-    },
-  },
-
-  sources = {
-    default = {
-      'lsp',
-      'path',
-      'snippets',
-      'buffer',
-      -- Wraps &omnifunc via blink.cmp.sources.complete_func. Built-in
-      -- `enabled` guard skips when omnifunc is the LSP handler, so no
-      -- duplication with the `lsp` source. Catches filetypes without
-      -- an LSP (gitcommit, help, plugin-provided completefuncs).
-      'omni',
-    },
-  },
-
-  -- Inline signature help while typing; disabled by default in blink.cmp.
-  signature = { enabled = true },
-}
+-- Lightweight LSP-aware completion from mini.nvim
+-- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-completion.md
+require('mini.completion').setup()
 
 -- ── Editor ───────────────────────────────────────────────────────────
 -- mini.nvim suite + vim-sleuth
@@ -200,7 +159,6 @@ miniclue.setup {
     miniclue.gen_clues.z(),
     { mode = 'n', keys = '<Leader>b', desc = '+Buffers' },
     { mode = 'n', keys = '<Leader>c', desc = '+Code' },
-    { mode = 'n', keys = '<Leader>cb', desc = '+CommentBox' },
     { mode = 'n', keys = '<Leader>cc', desc = '+Calls' },
     { mode = 'n', keys = '<Leader>q', desc = '+Quit' },
     { mode = 'n', keys = '<Leader>s', desc = '+Search' },
@@ -357,11 +315,10 @@ require 'lspconfig'
 
 require('mason').setup {}
 
--- blink.cmp is loaded by vim.pack.add earlier in this file.
 -- Set capabilities before mason-lspconfig enables servers so the config store
 -- is fully populated regardless of enable timing.
 vim.lsp.config('*', {
-  capabilities = require('blink.cmp').get_lsp_capabilities(),
+  capabilities = vim.lsp.protocol.make_client_capabilities(),
 })
 
 -- Automatically calls vim.lsp.enable() for every server mason has installed.
@@ -585,9 +542,9 @@ require('shellspec').setup {
   indent_comments = true,
 }
 
--- Clarify and beautify your comments using boxes and lines.
--- https://github.com/LudoPinelli/comment-box.nvim
-require('comment-box').setup {}
+-- Toggle comments (gc operator, gcc for line)
+-- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-comment.md
+require('mini.comment').setup()
 
 -- ── Treesitter ────────────────────────────────────────────────────────
 -- Parser manager for Neovim 0.12+ (highlight, indent, folds via built-in API)
@@ -644,14 +601,6 @@ require('colorizer').setup {
   user_default_options = {
     names = false,
   },
-}
-
--- ── Render Markdown ──────────────────────────────────────────────────
--- Render markdown inline (tables, headings, code blocks)
--- https://github.com/MeanderingProgrammer/render-markdown.nvim
-require('render-markdown').setup {
-  -- html and yaml parsers are in treesitter ensure_installed; latex is not.
-  latex = { enabled = false },
 }
 
 -- vim: set ts=2 sts=2 sw=2 wrap et :

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -162,6 +162,7 @@ miniclue.setup {
     { mode = 'n', keys = '<Leader>b', desc = '+Buffers' },
     { mode = 'n', keys = '<Leader>c', desc = '+Code' },
     { mode = 'n', keys = '<Leader>cc', desc = '+Calls' },
+    { mode = 'n', keys = '<Leader>p', desc = '+Pack' },
     { mode = 'n', keys = '<Leader>q', desc = '+Quit' },
     { mode = 'n', keys = '<Leader>s', desc = '+Search' },
     { mode = 'n', keys = '<Leader>t', desc = '+Toggle' },

--- a/config/nvim/lsp/intelephense.lua
+++ b/config/nvim/lsp/intelephense.lua
@@ -1,5 +1,6 @@
 return {
   init_options = {
-    licenceKey = vim.env.INTELEPHENSE_LICENSE or GetIntelephenseLicense() or nil,
+    -- Chain: $INTELEPHENSE_LICENSE env var → ~/intelephense/license.txt → nil (free tier)
+    licenceKey = vim.env.INTELEPHENSE_LICENSE or GetIntelephenseLicense(),
   },
 }

--- a/config/nvim/lsp/lua_ls.lua
+++ b/config/nvim/lsp/lua_ls.lua
@@ -7,9 +7,9 @@ return {
         -- globals list is authoritative in .luarc.json
         disable = { 'missing-fields' },
       },
-      completion = { callSnippet = 'Replace' },
+      completion = { callSnippet = 'Replace' }, -- show full call snippet, not just name
       workspace = {
-        checkThirdParty = false,
+        checkThirdParty = false, -- suppress "Do you want to configure this?" prompts
         library = { vim.env.VIMRUNTIME },
       },
       hint = {
@@ -18,8 +18,8 @@ return {
         await = true,
         paramName = 'All',
         paramType = true,
-        semicolon = 'SameLine',
-        setType = false,
+        semicolon = 'SameLine', -- show ; hint on same line as single-expr returns
+        setType = false, -- type on assignment is visible from the rhs; skip the hint
       },
     },
   },

--- a/config/nvim/lsp/lua_ls.lua
+++ b/config/nvim/lsp/lua_ls.lua
@@ -13,13 +13,8 @@ return {
         library = { vim.env.VIMRUNTIME },
       },
       hint = {
-        enable = true,
-        arrayIndex = 'Auto',
-        await = true,
-        paramName = 'All',
-        paramType = true,
-        semicolon = 'SameLine', -- show ; hint on same line as single-expr returns
-        setType = false, -- type on assignment is visible from the rhs; skip the hint
+        enable = true, -- hints are off by default; enable globally
+        paramType = true, -- show type hint on assignment rhs (default false)
       },
     },
   },

--- a/config/nvim/lsp/yamlls.lua
+++ b/config/nvim/lsp/yamlls.lua
@@ -9,11 +9,6 @@ return {
     -- redhat.telemetry is read top-level by yaml-language-server
     redhat = { telemetry = { enabled = false } },
     yaml = {
-      keyOrdering = false,
-      format = { enable = true, singleQuote = false, bracketSpacing = true },
-      validate = true,
-      hover = true,
-      completion = true,
       schemaStore = {
         enable = true,
         url = 'https://www.schemastore.org/api/json/catalog.json',

--- a/config/nvim/lua/autogroups.lua
+++ b/config/nvim/lua/autogroups.lua
@@ -50,13 +50,6 @@ autocmd('FileType', {
   end,
 })
 
--- make it easier to close man-files when opened inline
-autocmd('FileType', {
-  group = augroup('man_unlisted', { clear = true }),
-  pattern = { 'man' },
-  callback = function(event) vim.bo[event.buf].buflisted = false end,
-})
-
 -- Pin special buffers to their window (replaces stickybuf.nvim)
 autocmd('FileType', {
   group = augroup('winfixbuf', { clear = true }),
@@ -86,8 +79,7 @@ autocmd('FileType', {
     'tex',
   },
   callback = function()
-    vim.opt_local.wrap = true
-    vim.opt_local.spell = true
+    vim.opt_local.spell = true -- default is off; text buffers always want spellcheck
   end,
 })
 
@@ -119,9 +111,8 @@ vim.diagnostic.config {
     },
   } or {},
   virtual_text = {
-    source = 'if_many',
-    spacing = 2,
-    format = function(diagnostic) return diagnostic.message end,
+    source = 'if_many', -- show [source] prefix when multiple LSPs active
+    spacing = 2, -- default is 4; 2 keeps it compact
   },
 }
 
@@ -249,6 +240,7 @@ autocmd('VimEnter', {
   callback = function()
     if vim.fn.argc() > 0 then return end
     if #vim.api.nvim_list_uis() == 0 then return end
+    ---@module 'mini.sessions'
     local sessions = require 'mini.sessions'
     local cwd = vim.fn.getcwd()
     local name = cwd:gsub('[/\\]', '%%')
@@ -265,6 +257,7 @@ autocmd('VimLeavePre', {
   group = augroup('auto-session-write', { clear = true }),
   callback = function()
     if #vim.api.nvim_list_uis() == 0 then return end
+    ---@module 'mini.sessions'
     local sessions = require 'mini.sessions'
     local cwd = vim.fn.getcwd()
     local name = cwd:gsub('[/\\]', '%%')
@@ -294,6 +287,7 @@ local biome_fts = {
 autocmd({ 'BufWritePost', 'BufReadPost', 'InsertLeave' }, {
   group = augroup('nvim-lint', { clear = true }),
   callback = function(args)
+    ---@module 'lint'
     local lint = require 'lint'
     local ft = vim.bo[args.buf].filetype
     if biome_fts[ft] and HasConfig('biome', args.buf) then lint.try_lint 'biomejs' end

--- a/config/nvim/lua/autogroups.lua
+++ b/config/nvim/lua/autogroups.lua
@@ -98,6 +98,13 @@ autocmd({ 'FileType' }, {
   callback = function() vim.opt_local.conceallevel = 0 end,
 })
 
+-- Disable mini.completion in Snacks.picker buffers (input + list)
+autocmd('FileType', {
+  group = augroup('minicompletion-picker-disable', { clear = true }),
+  pattern = { 'snacks_picker_input', 'snacks_picker_list' },
+  callback = function(event) vim.b[event.buf].minicompletion_disable = true end,
+})
+
 -- ── Diagnostic Config ────────────────────────────────────────────────
 vim.diagnostic.config {
   severity_sort = true,

--- a/config/nvim/lua/keymaps.lua
+++ b/config/nvim/lua/keymaps.lua
@@ -125,8 +125,10 @@ K.nl('qQ', function()
 end, 'Force quit without saving')
 
 -- ── Snacks keymaps ──────────────────────────────────────────────────
--- All keymaps below require Snacks. Defined only when it is available.
-if Snacks then
+-- Deferred: keymaps.lua loads before vim.pack.add, so Snacks is not yet
+-- available at require time. vim.schedule runs after init.lua completes.
+vim.schedule(function()
+  if not Snacks then return end
   local s = Snacks
   local sp = Snacks.picker
 
@@ -159,6 +161,6 @@ if Snacks then
   -- Toggle (Snacks-powered)
   K.nl('tn', function() s.notifier.hide() end, 'Dismiss Notifications')
   K.nl('tt', function() s.terminal() end, 'Toggle Terminal')
-end
+end)
 
 -- That concludes the keymaps section of the config.

--- a/config/nvim/lua/keymaps.lua
+++ b/config/nvim/lua/keymaps.lua
@@ -111,6 +111,9 @@ K.nl(
 K.nl('tms', function() vim.o.spell = not vim.o.spell end, 'Toggle spell')
 K.nl('tmw', function() vim.o.wrap = not vim.o.wrap end, 'Toggle wrap')
 
+-- ── Pack UI ─────────────────────────────────────────────────────────
+K.nl('pp', '<cmd>Pack<cr>', 'Open plugin manager')
+
 -- ── Quit operations ─────────────────────────────────────────────────
 -- Convention is 'q' followed by the operation
 K.nl('qf', '<cmd>q<CR>', 'Quicker close split')
@@ -162,5 +165,3 @@ vim.schedule(function()
   K.nl('tn', function() s.notifier.hide() end, 'Dismiss Notifications')
   K.nl('tt', function() s.terminal() end, 'Toggle Terminal')
 end)
-
--- That concludes the keymaps section of the config.

--- a/config/nvim/lua/keymaps.lua
+++ b/config/nvim/lua/keymaps.lua
@@ -66,83 +66,7 @@ K.nl('bw', '<cmd>lua MiniBufremove.wipeout()<CR>', 'Wipeout')
 -- unless it's a generic operation like signature help or hover
 
 K.n('<C-l>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', { desc = 'Signature' })
-K.ld('cci', 'n', function()
-  if Snacks then Snacks.picker.lsp_incoming_calls() end
-end, 'Incoming calls')
-K.ld('cco', 'n', function()
-  if Snacks then Snacks.picker.lsp_outgoing_calls() end
-end, 'Outgoing calls')
-K.ld('cd', 'n', function()
-  if Snacks then Snacks.picker.lsp_definitions() end
-end, 'Definitions')
 K.ld('cf', { 'n', 'x' }, '<cmd>lua vim.lsp.buf.format()<CR>', 'Format')
-K.ld('ci', 'n', function()
-  if Snacks then Snacks.picker.lsp_implementations() end
-end, 'Implementations')
-K.ld('cp', 'n', function()
-  if Snacks then Snacks.picker.lsp_type_definitions() end
-end, 'Type Definition')
-K.ld('cr', 'n', function()
-  if Snacks then Snacks.rename.rename_file() end
-end, 'Rename file')
-K.ld('cs', 'n', function()
-  if Snacks then Snacks.picker.lsp_symbols() end
-end, 'LSP Document Symbols')
-K.ld('ct', 'n', function()
-  if Snacks then Snacks.picker.treesitter() end
-end, 'Treesitter')
-K.ld('cws', 'n', function()
-  if Snacks then Snacks.picker.lsp_workspace_symbols() end
-end, 'Workspace Symbols')
-
--- ── CommentBox operations ───────────────────────────────────────────
--- Mappings for creating and managing comment boxes
--- Convention: All mappings start with 'cb' followed by the box type
-K.nl('cbb', '<Cmd>CBccbox<CR>', 'CB: Box Title')
-K.nl('cbd', '<Cmd>CBd<CR>', 'CB: Remove a box')
-K.nl('cbl', '<Cmd>CBline<CR>', 'CB: Simple Line')
-K.nl('cbm', '<Cmd>CBllbox14<CR>', 'CB: Marked')
-K.nl('cbt', '<Cmd>CBllline<CR>', 'CB: Titled Line')
-
--- ── Search / Picker operations ──────────────────────────────────────
--- Powered by snacks.picker (replaces telescope).
--- Convention: All mappings start with 's' followed by the operation,
--- or generic 'f' for files and ',' for buffers.
-
-K.nl('f', function()
-  if Snacks then Snacks.picker.files() end
-end, 'Find Files')
-K.nl(',', function()
-  if Snacks then Snacks.picker.buffers() end
-end, 'Find existing buffers')
-
-K.nl('sd', function()
-  if Snacks then Snacks.picker.diagnostics() end
-end, 'Search Diagnostics')
-K.nl('sf', function()
-  if Snacks then Snacks.picker.grep_word() end
-end, 'Grep String')
-K.nl('sg', function()
-  if Snacks then Snacks.picker.grep() end
-end, 'Live Grep')
-K.nl('sh', function()
-  if Snacks then Snacks.picker.help() end
-end, 'Help tags')
-K.nl('sk', function()
-  if Snacks then Snacks.picker.keymaps() end
-end, 'Search Keymaps')
-K.nl('sn', function()
-  if Snacks then Snacks.picker.notifications() end
-end, 'Notification History')
-K.nl('so', function()
-  if Snacks then Snacks.picker.recent() end
-end, 'Old Files')
-K.nl('sq', function()
-  if Snacks then Snacks.picker.qflist() end
-end, 'Quickfix')
-K.nl('ss', function()
-  if Snacks then Snacks.picker.lines() end
-end, 'Search Buffer Lines')
 
 -- ── Trouble operations ──────────────────────────────────────────────
 -- Convention is 'x' followed by the operation
@@ -162,12 +86,6 @@ K.n('-', function()
   if MiniFiles then MiniFiles.open(vim.api.nvim_buf_get_name(0)) end
 end, { desc = 'File Explorer (current file)' })
 K.nl('tl', ToggleBackground, 'Toggle Light/Dark Mode')
-K.nl('tn', function()
-  if Snacks then Snacks.notifier.hide() end
-end, 'Dismiss Notifications')
-K.nl('tt', function()
-  if Snacks then Snacks.terminal() end
-end, 'Toggle Terminal')
 
 -- ── Option toggles ────────────────────────────────────────────────────
 -- Convention is 'tm' followed by the option letter
@@ -192,7 +110,6 @@ K.nl(
 )
 K.nl('tms', function() vim.o.spell = not vim.o.spell end, 'Toggle spell')
 K.nl('tmw', function() vim.o.wrap = not vim.o.wrap end, 'Toggle wrap')
-K.nl('tmm', '<cmd>RenderMarkdown toggle<CR>', 'Toggle markdown render')
 
 -- ── Quit operations ─────────────────────────────────────────────────
 -- Convention is 'q' followed by the operation
@@ -206,5 +123,42 @@ K.nl('qQ', function()
     vim.cmd 'q!'
   end
 end, 'Force quit without saving')
+
+-- ── Snacks keymaps ──────────────────────────────────────────────────
+-- All keymaps below require Snacks. Defined only when it is available.
+if Snacks then
+  local s = Snacks
+  local sp = Snacks.picker
+
+  -- Code & LSP (Snacks-powered pickers + rename)
+  -- Convention: 'c' prefix, matching the non-Snacks LSP keymaps above
+  K.ld('cci', 'n', function() sp.lsp_incoming_calls() end, 'Incoming calls')
+  K.ld('cco', 'n', function() sp.lsp_outgoing_calls() end, 'Outgoing calls')
+  K.ld('cd', 'n', function() sp.lsp_definitions() end, 'Definitions')
+  K.ld('ci', 'n', function() sp.lsp_implementations() end, 'Implementations')
+  K.ld('cp', 'n', function() sp.lsp_type_definitions() end, 'Type Definition')
+  K.ld('cr', 'n', function() s.rename.rename_file() end, 'Rename file')
+  K.ld('cs', 'n', function() sp.lsp_symbols() end, 'LSP Document Symbols')
+  K.ld('ct', 'n', function() sp.treesitter() end, 'Treesitter')
+  K.ld('cws', 'n', function() sp.lsp_workspace_symbols() end, 'Workspace Symbols')
+
+  -- Search / Picker
+  -- Convention: 's' prefix; 'f' and ',' for the two most common pickers
+  K.nl('f', function() sp.files() end, 'Find Files')
+  K.nl(',', function() sp.buffers() end, 'Find existing buffers')
+  K.nl('sd', function() sp.diagnostics() end, 'Search Diagnostics')
+  K.nl('sf', function() sp.grep_word() end, 'Grep String')
+  K.nl('sg', function() sp.grep() end, 'Live Grep')
+  K.nl('sh', function() sp.help() end, 'Help tags')
+  K.nl('sk', function() sp.keymaps() end, 'Search Keymaps')
+  K.nl('sn', function() sp.notifications() end, 'Notification History')
+  K.nl('so', function() sp.recent() end, 'Old Files')
+  K.nl('sq', function() sp.qflist() end, 'Quickfix')
+  K.nl('ss', function() sp.lines() end, 'Search Buffer Lines')
+
+  -- Toggle (Snacks-powered)
+  K.nl('tn', function() s.notifier.hide() end, 'Dismiss Notifications')
+  K.nl('tt', function() s.terminal() end, 'Toggle Terminal')
+end
 
 -- That concludes the keymaps section of the config.

--- a/config/nvim/lua/options.lua
+++ b/config/nvim/lua/options.lua
@@ -12,11 +12,10 @@ local o = vim.opt -- A table to store global options
 g.mapleader = ' ' -- Space as the leader key
 g.maplocalleader = ' ' -- Space as the local leader key
 
--- Nerd Font is installed (Brewfile / fonts) — used by mini.icons, blink.cmp,
+-- Nerd Font is installed (Brewfile / fonts) — used by mini.icons
 -- and the diagnostic-sign branch in lua/autogroups.lua. Set explicitly so
 -- the nil-fallback paths don't silently disable nerd-font glyphs.
 g.have_nerd_font = true
-g.nerd_font_variant = 'mono' -- 'mono' or 'normal' (blink.cmp appearance)
 
 g.editorconfig = true -- Make sure editorconfig support is enabled
 g.loaded_perl_provider = 0 -- Disable perl provider

--- a/config/nvim/lua/options.lua
+++ b/config/nvim/lua/options.lua
@@ -5,10 +5,10 @@
 --     `:help vim.g`
 -- For more options, you can see `:help option-list`
 
-local g = vim.g -- A table to store global variables
-local o = vim.opt -- A table to store global options
+local g = vim.g
+local o = vim.opt
 
--- vim.global
+-- vim.g
 g.mapleader = ' ' -- Space as the leader key
 g.maplocalleader = ' ' -- Space as the local leader key
 
@@ -17,25 +17,27 @@ g.maplocalleader = ' ' -- Space as the local leader key
 -- the nil-fallback paths don't silently disable nerd-font glyphs.
 g.have_nerd_font = true
 
-g.editorconfig = true -- Make sure editorconfig support is enabled
 g.loaded_perl_provider = 0 -- Disable perl provider
 g.loaded_ruby_provider = 0 -- Disable ruby provider
-g.loaded_java_provider = 0 -- Disable java provider
+g.loaded_node_provider = 0 -- Disable node provider
 
 -- vim.options
 o.confirm = true -- Confirm before closing unsaved buffers
-o.dictionary = '/usr/share/dict/words' -- Add system dictionary
+o.laststatus = 3 -- Global statusline (one bar; 0=hidden, 2=per-window, 3=global)
+o.dictionary = '/usr/share/dict/words' -- enables <C-x><C-k> word completion
 o.ignorecase = true -- Ignore case in search patterns
 o.inccommand = 'split' -- Preview substitutions live, as you type!
 o.list = true -- Show invisible characters
-o.listchars = { tab = '» ', trail = '·', nbsp = '␣' }
+o.listchars = { tab = '» ', trail = '·', nbsp = '␣' } -- glyphs: tab, trailing ws, nbsp
+-- eob=' ' hides ~ past EOF; fold glyphs rendered by the custom statuscolumn
 o.fillchars = { eob = ' ', foldopen = '▾', foldclose = '▸', foldsep = ' ' }
 o.number = true -- Show line numbers
-o.numberwidth = 3 -- Set the width of the number column
+o.numberwidth = 3 -- ≤99 lines; numberwidth-adjust autocmd expands for larger files
 o.relativenumber = true -- Show relative line numbers
 o.scrolloff = 8 -- Show context around cursor
 o.sidescrolloff = 8 -- Show context around cursor
 o.signcolumn = 'yes' -- Keep signcolumn on by default
+-- statuscolumn: signs | line number (abs on cursor, rel elsewhere) | fold
 -- stylua: ignore
 local fc = '%{foldlevel(v:lnum) > 0'
   .. ' ? (foldlevel(v:lnum) > foldlevel(v:lnum - 1)'
@@ -49,8 +51,8 @@ o.spelllang = 'en_gb,en_us' -- Set the spell checking language
 o.splitbelow = true -- split to the bottom
 o.splitright = true -- vsplit to the right
 o.termguicolors = true -- Enable GUI colors
-o.timeoutlen = 250 -- Decrease mapped sequence wait time
-o.updatetime = 250 -- 250 ms = 0.25 seconds
+o.timeoutlen = 250 -- key sequence wait in ms (default 1000); affects clue popup speed
+o.updatetime = 250 -- faster CursorHold: LSP highlights, gitsigns (default 4000)
 o.undofile = true -- Persistent undo across sessions
 o.cursorline = true -- Highlight current line
 o.linebreak = true -- Break lines at word boundaries
@@ -59,37 +61,32 @@ o.smartcase = true -- Smart case for search (with ignorecase)
 o.infercase = true -- Smart case for completion
 o.smartindent = true -- Auto indentation
 o.virtualedit = 'block' -- Virtual editing in visual block mode
-o.completeopt = 'menuone,noselect' -- Completion menu behavior
-o.formatoptions = 'qjl1' -- Comment formatting
+o.completeopt = { 'menuone', 'noselect', 'popup' } -- no auto-select; popup docs
+o.formatoptions = 'qjl1' -- q=gq on comments; j=strip leader on join; l,1=no insert-break
 o.mouse = 'a' -- Enable mouse support
-o.backup = false -- Don't create backup files
 o.writebackup = false -- Don't backup on write
-o.pumblend = 10 -- Transparent popup menu
-o.pumheight = 10 -- Popup menu max height
-o.winblend = 10 -- Transparent floating windows
+o.pumblend = 10 -- Transparent popup menu (0 = opaque)
+o.pumheight = 10 -- Popup menu max height (0 = unlimited)
+o.winblend = 10 -- Transparent floating windows (0 = opaque)
+o.ruler = false -- position shown in mini.statusline; ruler in cmdline is redundant
 
--- Folding via treesitter
+-- Folding via treesitter (native; no plugin required)
 o.foldmethod = 'expr'
-o.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
-o.foldtext = ''
-o.foldcolumn = '0'
-o.foldlevel = 99
-o.foldlevelstart = 99
+o.foldexpr = 'v:lua.vim.treesitter.foldexpr()' -- Neovim 0.10+ native treesitter API
+o.foldtext = '' -- '' = Neovim 0.10+ native display: first line + syntax highlight
+o.foldlevel = 99 -- keep all folds open during editing
+o.foldlevelstart = 99 -- open all folds when a file is first opened
 
--- Session options
--- This is a comma separated list of options that will be
--- saved when a session ends.
-local so = 'buffers,curdir,folds,tabpages,winsize,winpos,terminal,localoptions'
-o.sessionoptions = so
+-- Compared to default (blank,buffers,curdir,folds,help,tabpages,winsize,terminal):
+-- dropped 'blank' (empty windows) and 'help'; added 'winpos' and 'localoptions'
+o.sessionoptions = 'buffers,curdir,folds,tabpages,winsize,winpos,terminal,localoptions'
 
 o.wildmode = 'longest:full,full' -- Command-line completion mode
 
--- Sync clipboard between OS and Neovim.
---  Schedule the setting after `UiEnter` because it can increase startup-time.
---  See `:help 'clipboard'`
+-- Sync clipboard with OS (unnamedplus). Deferred via vim.schedule to avoid
+-- startup overhead. Disabled in SSH sessions: SSH_TTY is set but clipboard
+-- tools (pbcopy/xclip) are unavailable over the tunnel. See :help 'clipboard'
 vim.schedule(function()
   local c = vim.env.SSH_TTY and '' or 'unnamedplus'
   o.clipboard = c
 end)
-
--- vim: ts=2 sts=2 sw=2 et

--- a/config/nvim/lua/pack-ui.lua
+++ b/config/nvim/lua/pack-ui.lua
@@ -1,0 +1,684 @@
+--
+-- Minimalistic vim.pack UI (TUI dashboard for plugin management)
+--
+-- Commands:
+--   :Pack            open the dashboard
+--   :Pack check      open + immediately check remote for updates
+--   :Pack update     close + run vim.pack.update() (all plugins)
+--   :Pack clean      close + remove all non-active (orphaned) plugins
+--
+-- Keymaps (buffer-local, active while the window is open):
+--   U        update all plugins (closes UI, runs vim.pack.update)
+--   u        update plugin under cursor
+--   C        check remote for new commits
+--   X        clean non-active plugins (orphans)
+--   D        delete plugin under cursor (non-active only)
+--   L        open the vim.pack update log
+--   <CR>     toggle plugin details / commit list
+--   A        show all commits when details are expanded
+--   ]]       jump to next plugin entry
+--   [[       jump to previous plugin entry
+--   ?        toggle keymap help
+--   q / Esc  close window
+--
+-- Original author: Andreas Schneider (asn) <asn@cryptomilk.org>
+-- Source: https://git.cryptomilk.org/users/asn/dotfiles.git/plain/
+--         dot_config/nvim/lua/plugins/pack-ui.lua
+-- Adapted and improved for ivuorinen's dotfiles.
+--
+
+local api = vim.api
+local ns = api.nvim_create_namespace 'pack_ui'
+
+-- Maximum number of commits shown before truncation in the expanded view.
+local MAX_COMMITS_PREVIEW = 10
+
+-- ── Highlights ───────────────────────────────────────────────────────
+
+local function setup_highlights()
+  local links = {
+    PackUiHeader = 'Title',
+    PackUiButton = 'Function',
+    PackUiPluginLoaded = 'String',
+    PackUiPluginNotLoaded = 'Comment',
+    PackUiPluginMissing = 'ErrorMsg',
+    PackUiUpdateAvailable = 'DiagnosticInfo',
+    PackUiBreaking = 'DiagnosticWarn',
+    PackUiVersion = 'Number',
+    PackUiSectionHeader = 'Label',
+    PackUiSeparator = 'FloatBorder',
+    PackUiDetail = 'Comment',
+    PackUiHelp = 'SpecialComment',
+  }
+  for group, target in pairs(links) do
+    api.nvim_set_hl(0, group, { link = target, default = true })
+  end
+end
+
+setup_highlights()
+
+-- ColorScheme events can invoke `highlight clear`, wiping `default` groups.
+-- Reapply so the UI is always styled regardless of theme changes.
+api.nvim_create_autocmd('ColorScheme', {
+  group = api.nvim_create_augroup('PackUiHighlights', { clear = true }),
+  callback = setup_highlights,
+})
+
+-- ── State ────────────────────────────────────────────────────────────
+
+local state = {
+  bufnr = nil,
+  winid = nil,
+  win_autocmd_id = nil,
+  line_to_plugin = {},
+  plugin_lines = {},
+  expanded = {},
+  show_help = false,
+  updates = {},
+  breaking = {},
+  unreleased_breaking = {},
+  show_all_commits = {},
+  latest_ref = {},
+  checking = false,
+  check_id = 0,
+}
+
+-- tag_cache is invalidated on every close because installed tags change
+-- after update operations. ref_cache persists for the session — the remote
+-- default branch is stable and re-resolution is expensive.
+local tag_cache = {}
+local ref_cache = {}
+
+-- ── Helpers ──────────────────────────────────────────────────────────
+
+-- For versioned plugins, return the installed git tag. Session-cached so
+-- git is only called once per plugin per open; cleared on close to avoid
+-- showing stale versions after an update.
+local function get_installed_tag(path)
+  if not path then return nil end
+  if tag_cache[path] ~= nil then return tag_cache[path] or nil end
+  local result = vim
+    .system(
+      { 'git', '-C', path, 'describe', '--tags', '--exact-match', 'HEAD' },
+      { text = true }
+    )
+    :wait()
+  if result.code == 0 then
+    local tag = vim.trim(result.stdout)
+    tag_cache[path] = tag
+    return tag
+  end
+  tag_cache[path] = false
+  return nil
+end
+
+local function get_version_str(p)
+  local v = p.spec.version
+  if v == nil then return '' end
+  if type(v) == 'string' then return v end
+  return tostring(v)
+end
+
+-- Parse semver from a tag string; returns {major, minor, patch} or nil.
+local function parse_semver(tag)
+  if not tag then return nil end
+  local major, minor, patch = tag:match '^v?(%d+)%.(%d+)%.(%d+)'
+  if major then return { tonumber(major), tonumber(minor), tonumber(patch) } end
+  return nil
+end
+
+local function parse_commits(stdout)
+  local commits = {}
+  if stdout and stdout ~= '' then
+    for line in stdout:gmatch '[^\n]+' do
+      table.insert(commits, line)
+    end
+  end
+  return commits
+end
+
+-- Resolve the remote default branch ref for a git repo.
+-- Tries symbolic-ref → origin/main → origin/master in order.
+-- Calls callback(ref) or callback(nil) on complete failure.
+local function resolve_remote_ref(path, callback)
+  if ref_cache[path] ~= nil then
+    callback(ref_cache[path] or nil)
+    return
+  end
+  vim.system(
+    { 'git', '-C', path, 'symbolic-ref', 'refs/remotes/origin/HEAD' },
+    { text = true },
+    function(r)
+      if r.code == 0 then
+        local ref = vim.trim(r.stdout)
+        ref_cache[path] = ref
+        callback(ref)
+        return
+      end
+      vim.system(
+        { 'git', '-C', path, 'rev-parse', '--verify', 'origin/main' },
+        { text = true },
+        function(r2)
+          if r2.code == 0 then
+            ref_cache[path] = 'origin/main'
+            callback 'origin/main'
+          else
+            vim.system(
+              { 'git', '-C', path, 'rev-parse', '--verify', 'origin/master' },
+              { text = true },
+              function(r3)
+                if r3.code == 0 then
+                  ref_cache[path] = 'origin/master'
+                  callback 'origin/master'
+                else
+                  ref_cache[path] = false
+                  callback(nil)
+                end
+              end
+            )
+          end
+        end
+      )
+    end
+  )
+end
+
+local function git_log(path, range, callback)
+  vim.system(
+    { 'git', '-C', path, 'log', '--oneline', range },
+    { text = true },
+    function(res) callback(parse_commits(res.code == 0 and res.stdout or '')) end
+  )
+end
+
+-- Forward declaration: check_updates calls render before it is defined.
+local render
+
+-- ── Update checking ──────────────────────────────────────────────────
+
+local function check_updates()
+  if state.checking then return end
+  state.check_id = state.check_id + 1
+  local my_check_id = state.check_id
+  state.checking = true
+  state.updates = {}
+  state.breaking = {}
+  state.unreleased_breaking = {}
+  state.latest_ref = {}
+  render()
+
+  local plugins = vim.pack.get(nil, { info = true })
+  local pending = #plugins
+  if pending == 0 then
+    state.checking = false
+    render()
+    return
+  end
+
+  local function finish_one(name, new_commits, is_breaking, unreleased)
+    if state.check_id ~= my_check_id then return end
+    if name and new_commits then
+      state.updates[name] = new_commits
+      if is_breaking then state.breaking[name] = true end
+      if unreleased and #unreleased > 0 then
+        state.unreleased_breaking[name] = unreleased
+      end
+    end
+    pending = pending - 1
+    if pending == 0 then state.checking = false end
+    vim.schedule(render)
+  end
+
+  for _, p in ipairs(plugins) do
+    local name = p.spec.name
+    local path = p.path
+
+    if not path or vim.fn.isdirectory(path) ~= 1 then
+      finish_one(nil, nil, nil, nil)
+    elseif get_version_str(p) ~= '' then
+      -- Versioned plugin: fetch tags and compare installed vs latest semver.
+      vim.system({ 'git', '-C', path, 'fetch', '--quiet', '--tags' }, {}, function(fr)
+        if fr.code ~= 0 then
+          finish_one(nil, nil, nil, nil)
+          return
+        end
+        vim.system(
+          { 'git', '-C', path, 'tag', '--sort=-version:refname' },
+          { text = true },
+          function(tr)
+            if tr.code ~= 0 then
+              finish_one(nil, nil, nil, nil)
+              return
+            end
+            local latest_tag = nil
+            for line in tr.stdout:gmatch '[^\n]+' do
+              if parse_semver(line) then
+                latest_tag = line
+                break
+              end
+            end
+            state.latest_ref[name] = latest_tag
+            local installed_tag = get_installed_tag(path)
+            if not latest_tag or latest_tag == installed_tag then
+              finish_one(name, {}, false, nil)
+              return
+            end
+            local installed_sv = parse_semver(installed_tag)
+            local latest_sv = parse_semver(latest_tag)
+            local is_breaking = installed_sv
+              and latest_sv
+              and latest_sv[1] > installed_sv[1]
+            local range = (installed_tag or 'HEAD') .. '..' .. latest_tag
+            git_log(
+              path,
+              range,
+              function(commits) finish_one(name, commits, is_breaking, nil) end
+            )
+          end
+        )
+      end)
+    else
+      -- Unversioned plugin: compare HEAD against remote default branch.
+      resolve_remote_ref(path, function(ref)
+        if not ref then
+          finish_one(nil, nil, nil, nil)
+          return
+        end
+        vim.system({ 'git', '-C', path, 'fetch', '--quiet' }, {}, function(fr)
+          if fr.code ~= 0 then
+            finish_one(nil, nil, nil, nil)
+            return
+          end
+          git_log(path, 'HEAD..' .. ref, function(commits)
+            -- Detect breaking commits: conventional `type!:` or `BREAKING CHANGE`.
+            local breaking = {}
+            for _, c in ipairs(commits) do
+              if c:match 'BREAKING' or c:match '%a[%w%(%)]*!:' then
+                table.insert(breaking, c)
+              end
+            end
+            finish_one(name, commits, false, breaking)
+          end)
+        end)
+      end)
+    end
+  end
+end
+
+-- ── Lifecycle ────────────────────────────────────────────────────────
+
+local function reset_state()
+  state.winid = nil
+  state.bufnr = nil
+  state.expanded = {}
+  state.show_help = false
+  state.updates = {}
+  state.breaking = {}
+  state.unreleased_breaking = {}
+  state.show_all_commits = {}
+  state.latest_ref = {}
+  state.checking = false
+  -- Increment to invalidate any in-flight check_updates callbacks.
+  state.check_id = state.check_id + 1
+  -- Invalidate tag cache: installed tags change after update operations.
+  tag_cache = {}
+end
+
+local function close()
+  -- Remove autocmd before closing to prevent races on re-open.
+  if state.win_autocmd_id then
+    pcall(api.nvim_del_autocmd, state.win_autocmd_id)
+    state.win_autocmd_id = nil
+  end
+  if state.winid and api.nvim_win_is_valid(state.winid) then
+    api.nvim_win_close(state.winid, true)
+  end
+  -- Buffer has bufhidden=wipe; destroyed automatically when window closes.
+  reset_state()
+end
+
+-- ── Navigation ───────────────────────────────────────────────────────
+
+local function plugin_at_cursor()
+  if not state.winid or not api.nvim_win_is_valid(state.winid) then return nil end
+  local row = api.nvim_win_get_cursor(state.winid)[1]
+  return state.line_to_plugin[row]
+end
+
+local function jump_plugin(direction)
+  if not state.winid or not api.nvim_win_is_valid(state.winid) then return end
+  local row = api.nvim_win_get_cursor(state.winid)[1]
+  local lines = vim.tbl_keys(state.line_to_plugin)
+  table.sort(lines)
+  if direction > 0 then
+    for _, ln in ipairs(lines) do
+      if ln > row then
+        api.nvim_win_set_cursor(state.winid, { ln, 0 })
+        return
+      end
+    end
+  else
+    for i = #lines, 1, -1 do
+      if lines[i] < row then
+        api.nvim_win_set_cursor(state.winid, { lines[i], 0 })
+        return
+      end
+    end
+  end
+end
+
+-- ── Rendering ────────────────────────────────────────────────────────
+
+render = function()
+  if not state.bufnr or not api.nvim_buf_is_valid(state.bufnr) then return end
+
+  local lines = {}
+  local hls = {}
+  local new_line_to_plugin = {}
+  local new_plugin_lines = {}
+
+  local function add(text, hl_group)
+    table.insert(lines, text)
+    if hl_group then
+      local ln0 = #lines - 1 -- 0-based for extmarks
+      table.insert(hls, { ln0, 0, #text, hl_group })
+    end
+  end
+
+  local function add_span(ln0, col_start, col_end, hl_group)
+    table.insert(hls, { ln0, col_start, col_end, hl_group })
+  end
+
+  -- Header
+  local header = ' vim.pack'
+  if state.checking then header = header .. '  (checking…)' end
+  add(header, 'PackUiHeader')
+  add(' ? for help · q/Esc to close', 'PackUiHelp')
+  add ''
+
+  local plugins = vim.pack.get(nil, { info = true })
+  table.sort(plugins, function(a, b) return (a.spec.name or '') < (b.spec.name or '') end)
+
+  for _, p in ipairs(plugins) do
+    local name = p.spec.name or '(unknown)'
+    local path = p.path
+    local is_missing = not path or vim.fn.isdirectory(path) ~= 1
+    local has_updates = state.updates[name] and #state.updates[name] > 0
+
+    local ln = #lines + 1 -- 1-based line number for cursor→plugin mapping
+    new_line_to_plugin[ln] = name
+    new_plugin_lines[name] = ln
+
+    local icon, icon_hl
+    if is_missing then
+      icon = '✗'
+      icon_hl = 'PackUiPluginMissing'
+    elseif has_updates then
+      icon = '↑'
+      icon_hl = 'PackUiUpdateAvailable'
+    elseif p.active then
+      icon = '●'
+      icon_hl = 'PackUiPluginLoaded'
+    else
+      icon = '○'
+      icon_hl = 'PackUiPluginNotLoaded'
+    end
+
+    local installed_tag = (not is_missing and get_version_str(p) ~= '')
+        and get_installed_tag(path)
+      or nil
+    local ver_display = installed_tag and (' [' .. installed_tag .. ']') or ''
+    local latest = state.latest_ref[name]
+    if latest and latest ~= installed_tag then
+      ver_display = ver_display .. ' → ' .. latest
+    end
+
+    local breaking = state.breaking[name]
+    local brk_suffix = breaking and '  ⚠ BREAKING' or ''
+    local line_text = ' ' .. icon .. ' ' .. name .. ver_display .. brk_suffix
+
+    local ln0 = #lines -- 0-based for extmarks
+    add(line_text)
+    -- Icon: byte 1 .. 1+#icon (icon bytes, not display width)
+    add_span(ln0, 1, 1 + #icon, icon_hl)
+    if ver_display ~= '' then
+      local ver_start = 1 + #icon + 1 + #name
+      add_span(ln0, ver_start, ver_start + #ver_display, 'PackUiVersion')
+    end
+    if breaking then
+      local brk_start = #line_text - #brk_suffix
+      add_span(ln0, brk_start, #line_text, 'PackUiBreaking')
+    end
+
+    if state.expanded[name] then
+      local updates = state.updates[name]
+      if updates and #updates > 0 then
+        local show_all = state.show_all_commits[name]
+        local display = show_all and updates
+          or { table.unpack(updates, 1, MAX_COMMITS_PREVIEW) }
+        for _, commit in ipairs(display) do
+          add('    ' .. commit, 'PackUiDetail')
+        end
+        if not show_all and #updates > MAX_COMMITS_PREVIEW then
+          add(
+            ('    … %d more  (press A to show all)'):format(
+              #updates - MAX_COMMITS_PREVIEW
+            ),
+            'PackUiDetail'
+          )
+        end
+      end
+
+      local unreleased = state.unreleased_breaking[name]
+      if unreleased then
+        add('  Breaking commits:', 'PackUiBreaking')
+        for _, c in ipairs(unreleased) do
+          add('    ' .. c, 'PackUiBreaking')
+        end
+      end
+
+      if path then add('  path: ' .. path, 'PackUiDetail') end
+    end
+  end
+
+  if state.show_help then
+    add ''
+    add(' Keymaps:', 'PackUiHelp')
+    add('   U       Update all plugins', 'PackUiHelp')
+    add('   u       Update plugin under cursor', 'PackUiHelp')
+    add('   C       Check remote for new commits', 'PackUiHelp')
+    add('   X       Clean non-active plugins', 'PackUiHelp')
+    add('   D       Delete plugin under cursor (non-active only)', 'PackUiHelp')
+    add('   L       Open update log file', 'PackUiHelp')
+    add('   <CR>    Toggle plugin details', 'PackUiHelp')
+    add('   A       Show all commits (expanded view)', 'PackUiHelp')
+    add('   ]]      Jump to next plugin', 'PackUiHelp')
+    add('   [[      Jump to previous plugin', 'PackUiHelp')
+    add('   q/Esc   Close window', 'PackUiHelp')
+    add('   ?       Toggle this help', 'PackUiHelp')
+  end
+
+  state.line_to_plugin = new_line_to_plugin
+  state.plugin_lines = new_plugin_lines
+
+  vim.bo[state.bufnr].modifiable = true
+  api.nvim_buf_set_lines(state.bufnr, 0, -1, false, lines)
+  vim.bo[state.bufnr].modifiable = false
+
+  api.nvim_buf_clear_namespace(state.bufnr, ns, 0, -1)
+  for _, hl in ipairs(hls) do
+    api.nvim_buf_set_extmark(state.bufnr, ns, hl[1], hl[2], {
+      end_col = hl[3],
+      hl_group = hl[4],
+    })
+  end
+end
+
+-- ── Keymaps ──────────────────────────────────────────────────────────
+
+local function setup_keymaps()
+  local buf = state.bufnr
+  local opts = { buffer = buf, silent = true, nowait = true }
+
+  vim.keymap.set('n', 'q', close, opts)
+  vim.keymap.set('n', '<Esc>', close, opts)
+
+  vim.keymap.set('n', '?', function()
+    state.show_help = not state.show_help
+    render()
+  end, opts)
+
+  vim.keymap.set('n', 'U', function()
+    close()
+    vim.pack.update()
+  end, opts)
+
+  vim.keymap.set('n', 'u', function()
+    local name = plugin_at_cursor()
+    if not name then return end
+    close()
+    vim.pack.update { name }
+  end, opts)
+
+  vim.keymap.set('n', 'C', check_updates, opts)
+
+  vim.keymap.set('n', 'X', function()
+    local all = vim.pack.get(nil, { info = false })
+    local orphans = {}
+    for _, p in ipairs(all) do
+      if not p.active then table.insert(orphans, p.spec.name) end
+    end
+    if #orphans == 0 then
+      vim.notify('PackUI: no orphaned plugins to remove', vim.log.levels.INFO)
+      return
+    end
+    close()
+    local ok, err = pcall(vim.pack.del, orphans)
+    if not ok then vim.notify('PackUI: ' .. tostring(err), vim.log.levels.ERROR) end
+  end, opts)
+
+  vim.keymap.set('n', 'D', function()
+    local name = plugin_at_cursor()
+    if not name then return end
+    local all = vim.pack.get(nil, { info = false })
+    for _, p in ipairs(all) do
+      if p.spec.name == name then
+        if p.active then
+          vim.notify(
+            'PackUI: plugin is active — use X to clean orphans or U to update',
+            vim.log.levels.WARN
+          )
+        else
+          close()
+          vim.pack.del { name }
+        end
+        return
+      end
+    end
+  end, opts)
+
+  vim.keymap.set('n', 'L', function()
+    local log_path = vim.fn.stdpath 'log' .. '/pack.log'
+    if vim.fn.filereadable(log_path) == 1 then
+      close()
+      vim.cmd.edit(log_path)
+    else
+      vim.notify('PackUI: log not found: ' .. log_path, vim.log.levels.WARN)
+    end
+  end, opts)
+
+  vim.keymap.set('n', '<CR>', function()
+    local name = plugin_at_cursor()
+    if not name then return end
+    state.expanded[name] = not state.expanded[name]
+    render()
+  end, opts)
+
+  vim.keymap.set('n', 'A', function()
+    local name = plugin_at_cursor()
+    if not name then return end
+    state.show_all_commits[name] = not state.show_all_commits[name]
+    render()
+  end, opts)
+
+  vim.keymap.set('n', ']]', function() jump_plugin(1) end, opts)
+  vim.keymap.set('n', '[[', function() jump_plugin(-1) end, opts)
+end
+
+-- ── Window ───────────────────────────────────────────────────────────
+
+local function open()
+  if state.winid and api.nvim_win_is_valid(state.winid) then
+    api.nvim_set_current_win(state.winid)
+    return
+  end
+
+  local width = math.floor(vim.o.columns * 0.7)
+  local height = math.floor(vim.o.lines * 0.8)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  state.bufnr = api.nvim_create_buf(false, true)
+  vim.bo[state.bufnr].buftype = 'nofile'
+  vim.bo[state.bufnr].bufhidden = 'wipe'
+  vim.bo[state.bufnr].swapfile = false
+  vim.bo[state.bufnr].filetype = 'pack-ui'
+  vim.bo[state.bufnr].modifiable = false
+
+  state.winid = api.nvim_open_win(state.bufnr, true, {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = 'minimal',
+    border = 'rounded',
+    title = ' vim.pack ',
+    title_pos = 'center',
+  })
+
+  vim.wo[state.winid].wrap = false
+  vim.wo[state.winid].cursorline = true
+
+  setup_keymaps()
+  render()
+
+  local captured_winid = state.winid
+  state.win_autocmd_id = api.nvim_create_autocmd('WinClosed', {
+    buffer = state.bufnr,
+    once = true,
+    callback = function(ev)
+      -- tonumber replaces the private vim._tointeger used in the original.
+      if tonumber(ev.match) ~= captured_winid then return end
+      state.win_autocmd_id = nil
+      reset_state()
+    end,
+  })
+end
+
+-- ── Commands ─────────────────────────────────────────────────────────
+
+vim.api.nvim_create_user_command('Pack', function(opts)
+  open()
+  if opts.args == 'check' then
+    check_updates()
+  elseif opts.args == 'update' then
+    close()
+    vim.pack.update()
+  elseif opts.args == 'clean' then
+    local all = vim.pack.get(nil, { info = false })
+    local orphans = {}
+    for _, p in ipairs(all) do
+      if not p.active then table.insert(orphans, p.spec.name) end
+    end
+    if #orphans > 0 then
+      close()
+      local ok, err = pcall(vim.pack.del, orphans)
+      if not ok then vim.notify('PackUI: ' .. tostring(err), vim.log.levels.ERROR) end
+    end
+  end
+end, {
+  nargs = '?',
+  complete = function() return { 'check', 'update', 'clean' } end,
+  desc = 'Open vim.pack plugin manager UI',
+})

--- a/config/nvim/lua/pack.lua
+++ b/config/nvim/lua/pack.lua
@@ -43,60 +43,25 @@ vim.api.nvim_create_user_command(
   }
 )
 
--- List all plugins in a floating window; inactive (orphans) shown first.
-vim.api.nvim_create_user_command('PackList', function()
-  local all = vim.pack.get(nil, { info = false })
-  local inactive, active = {}, {}
-  for _, p in ipairs(all) do
-    if p.active then
-      table.insert(active, p.spec.name)
-    else
-      table.insert(inactive, p.spec.name)
-    end
-  end
-  table.sort(inactive)
-  table.sort(active)
-
-  local lines = {}
-  if #inactive > 0 then
-    table.insert(lines, ('NOT USED (%d):'):format(#inactive))
-    for _, n in ipairs(inactive) do
-      table.insert(lines, '  ' .. n)
-    end
-    if #active > 0 then table.insert(lines, '') end
-  end
-  table.insert(lines, ('USED (%d):'):format(#active))
-  for _, n in ipairs(active) do
-    table.insert(lines, '  ' .. n)
-  end
-
-  local max_len = 0
-  for _, line in ipairs(lines) do
-    max_len = math.max(max_len, #line)
-  end
-  local w = math.max(1, math.min(math.max(max_len + 4, 34), vim.o.columns - 4))
-  local h = math.max(1, math.min(#lines, vim.o.lines - 6))
-
-  local buf = vim.api.nvim_create_buf(false, true)
-  vim.bo[buf].bufhidden = 'wipe'
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-  vim.bo[buf].modifiable = false
-
-  vim.api.nvim_open_win(buf, true, {
-    relative = 'editor',
-    width = w,
-    height = h,
-    row = math.floor((vim.o.lines - h) / 2),
-    col = math.floor((vim.o.columns - w) / 2),
-    style = 'minimal',
-    border = 'rounded',
-    title = ' PackList ',
-    title_pos = 'center',
-  })
-  vim.keymap.set(
-    'n',
-    'q',
-    '<cmd>close<cr>',
-    { buffer = buf, silent = true, desc = 'Close' }
-  )
-end, { desc = 'List vim.pack plugins; inactive (orphans) first' })
+-- Close the vim.pack confirm buffer (filetype nvim-pack) with q or Esc.
+-- :w confirms and runs the update; closing cancels via Neovim's own on_cancel.
+vim.api.nvim_create_autocmd('FileType', {
+  group = vim.api.nvim_create_augroup('nvim_pack_close', { clear = true }),
+  pattern = 'nvim-pack',
+  callback = function(event)
+    local close = '<cmd>close<cr>'
+    local opts = { buffer = event.buf, silent = true }
+    vim.keymap.set(
+      'n',
+      'q',
+      close,
+      vim.tbl_extend('force', opts, { desc = 'Cancel update' })
+    )
+    vim.keymap.set(
+      'n',
+      '<Esc>',
+      close,
+      vim.tbl_extend('force', opts, { desc = 'Cancel update' })
+    )
+  end,
+})

--- a/config/nvim/lua/utils.lua
+++ b/config/nvim/lua/utils.lua
@@ -1,12 +1,8 @@
--- These are my utility functions
--- I use to make my life bit easier
-
 -- ╭─────────────────────────────────────────────────────────╮
 -- │            Function shortcuts for keymap set            │
 -- ╰─────────────────────────────────────────────────────────╯
 
 -- Keymap set shortcut
---@type vim.keymap.set
 local s = vim.keymap.set
 
 -- Keymap shortcut functions
@@ -17,8 +13,6 @@ K = {}
 ---@return table -- The description as a table.
 local function handleDesc(desc)
   if type(desc) == 'string' then
-    -- Convert string to table with `desc` as a key
-    -- If the string is empty, just return as an empty description
     return { desc = desc }
   elseif type(desc) == 'table' then
     if desc.desc then return desc end
@@ -26,8 +20,7 @@ local function handleDesc(desc)
     -- across multiple K.n() calls and we don't want a leftover desc='?'.
     return vim.tbl_extend('force', desc, { desc = '?' })
   else
-    -- Default to an empty table if `desc` is nil or an unsupported type
-    return { desc = '?' }
+    return { desc = '?' } -- nil or unsupported type: surface as unlabelled binding
   end
 end
 
@@ -102,7 +95,7 @@ end
 -- Marker files per tool, keyed by logical name. Used to detect whether
 -- a project has opted into a given formatter/linter before running it.
 -- Shared between conform (via Gated()) and nvim-lint (via HasConfig()
--- in lua/plugins/qa.lua's LINTER_GATES). Extend this table to gate a
+-- in lua/autogroups.lua's LINTER_GATES). Extend this table to gate a
 -- new tool; keys are referenced by string from consumers.
 ---@type table<string, string[]>
 TOOL_CONFIGS = {

--- a/config/nvim/nvim-pack-lock.json
+++ b/config/nvim/nvim-pack-lock.json
@@ -8,18 +8,9 @@
       "rev": "54058b4fe414bd64bd2904a6f8a63f1f14e3d8df",
       "src": "https://github.com/f-person/auto-dark-mode.nvim"
     },
-    "blink.cmp": {
-      "rev": "78336bc89ee5365633bcf754d93df01678b5c08f",
-      "src": "https://github.com/saghen/blink.cmp",
-      "version": ">=0.0.0"
-    },
     "catppuccin": {
       "rev": "0303a7208dba448c459767486a38a6ec05c4216b",
       "src": "https://github.com/catppuccin/nvim"
-    },
-    "comment-box.nvim": {
-      "rev": "06bb771690bc9df0763d14769b779062d8f12bc5",
-      "src": "https://github.com/LudoPinelli/comment-box.nvim"
     },
     "conform.nvim": {
       "rev": "619363c30309d29ffa631e67c8183f2a72caa373",
@@ -60,10 +51,6 @@
     "nvim-shellspec": {
       "rev": "94bbbf796dfafb0798298835ab715e1650f0de25",
       "src": "https://github.com/ivuorinen/nvim-shellspec"
-    },
-    "render-markdown.nvim": {
-      "rev": "5adf0895310c1904e5abfaad40a2baad7fe44a07",
-      "src": "https://github.com/MeanderingProgrammer/render-markdown.nvim"
     },
     "snacks.nvim": {
       "rev": "e6fd58c82f2f3fcddd3fe81703d47d6d48fc7b9f",


### PR DESCRIPTION
## Summary

- **Replace blink.cmp with mini.completion** — drops a heavy plugin in favour of the mini.nvim completion that is already on the rtp; disables it in Snacks picker buffers to avoid interference
- **Add pack-ui TUI** (`lua/pack-ui.lua`) — interactive browser for `vim.pack` plugins (check, update, clean); based on asn's original with attribution; fixes `tonumber()` vs private `vim._tointeger()`, `table.unpack()`, `ColorScheme` autocmd for persistent highlights, `tag_cache` reset, and `:Pack clean` via `vim.pack.del` (replaces the non-existent `vim.pack.clean()`)
- **Snacks keymap deferral** — moved Snacks keymaps into `vim.schedule` so they register after plugins are loaded
- **Config annotation pass** — inline comments on options, LSP settings, and ftdetect explaining the non-obvious choices; trim yamlls keys that duplicate server defaults

## Commits

| Hash | Change |
|------|--------|
| `cac6e5a` | refactor(nvim): replace blink.cmp with mini.completion and mini.comment; drop render-markdown |
| `a1aabd6` | refactor(nvim): consolidate Snacks keymaps under single availability guard |
| `62b9bee` | feat(nvim): disable mini.completion in Snacks picker buffers |
| `4497bc9` | docs(nvim): update CLAUDE.md and README.md for plugin changes |
| `97cc07d` | fix(nvim): defer Snacks keymaps until after plugins are loaded |
| `3291efa` | feat(nvim): add pack-ui TUI for vim.pack plugin management |
| `483c62e` | refactor(nvim): annotate and clean up options, autogroups, utils |
| `f497508` | refactor(nvim): annotate LSP configs and trim yamlls defaults |
| `64c8008` | chore(nvim): update plugin lock file |

## Test plan

- [ ] `:Pack` opens the TUI; `u` triggers update, `X` removes orphans, `q`/`<Esc>` closes
- [ ] `vim.pack.update()` confirm buffer closes with `q` and `<Esc>` (no write = cancel)
- [ ] `<leader>pp` opens `:Pack`
- [ ] Completion works in normal buffers; absent in Snacks picker input/list
- [ ] Snacks picker keymaps (`<leader>f`, `<leader>sg`, etc.) work after startup
- [ ] LSP servers attach and provide completions/diagnostics as before